### PR TITLE
feat: creditors

### DIFF
--- a/e2e/tests/features/creditors.feature
+++ b/e2e/tests/features/creditors.feature
@@ -1,0 +1,57 @@
+Feature: Creditors
+  Background:
+    Given a database with some accounts
+    Given some role assignments
+    Given some payments are received
+
+    Scenario: Admins with the ReadAll role can see all creditors
+      When Admin authenticates with nonce = 1 and roles = "read_all"
+      When Admin GETs to "/api/creditors" with body
+      Then I receive a 200 Ok response
+      Then I receive a partial JSON response:
+      """
+      [
+        {"id":1,"total_received":115000000,"current_pending":115000000,"current_balance":0,"total_orders":165000000,"current_orders":165000000},
+        {"id":2,"total_received":550000000,"current_pending":550000000,"current_balance":0,"total_orders":550000000,"current_orders":550000000},
+        {"id":4,"total_received":700000000,"current_pending":700000000,"current_balance":0,"total_orders":0,"current_orders":0}
+      ]
+      """
+      When payment alicepayment001 is confirmed
+      When payment bobpayment001 is confirmed
+      When Admin GETs to "/api/creditors" with body
+      Then I receive a 200 Ok response
+      Then I receive a partial JSON response:
+      """
+      [
+        {"id":1,"total_received":115000000,"current_pending":100000000,"current_balance":15000000,"total_orders":165000000,"current_orders":165000000},
+        {"id":2,"total_received":550000000,"current_pending":500000000,"current_balance":50000000,"total_orders":550000000,"current_orders":550000000},
+        {"id":4,"total_received":700000000,"current_pending":700000000,"current_balance":0,"total_orders":0,"current_orders":0}
+      ]
+      """
+
+      # This will cover the 100XTR order, but not the 65 XTR order as well
+      When payment alicepayment002 is confirmed
+      # This covers both Bob's orders, and he has zero balance left, so not a creditor anymore
+      When payment bobpayment002 is confirmed
+      # No orders for this user, just a positive current balance now
+      When payment anonpayment001 is confirmed
+      When Admin GETs to "/api/creditors" with body
+      Then I receive a 200 Ok response
+      Then I receive a partial JSON response:
+      """
+      [
+        {"id":1,"total_received":115000000,"current_pending":0,"current_balance":15000000,"total_orders":165000000,"current_orders":65000000},
+        {"id":4,"total_received":700000000,"current_pending":0,"current_balance":700000000,"total_orders":0,"current_orders":0}
+      ]
+      """
+
+  Scenario: Unauthenticated user cannot access the `creditors` endpoint
+    When User GETs to "/api/creditors" with body
+    Then I receive a 401 Unauthenticated response with the message 'An error occurred, no cookie containing a jwt was found in the request.'
+
+  Scenario: Standard user cannot access the `creditors` endpoint
+    When Alice authenticates with nonce = 1 and roles = "user"
+    When Alice GETs to "/api/creditors" with body
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+

--- a/tari_payment_engine/src/sqlite/db/user_accounts.rs
+++ b/tari_payment_engine/src/sqlite/db/user_accounts.rs
@@ -431,3 +431,24 @@ pub(crate) async fn history_for_id(
         .with_payments(all_payments);
     Ok(Some(result))
 }
+
+pub(crate) async fn creditors(conn: &mut SqliteConnection) -> Result<Vec<UserAccount>, AccountApiError> {
+    let accounts = sqlx::query_as!(
+        UserAccount,
+        r#"
+        SELECT
+            id,
+            created_at as "created_at: chrono::DateTime<chrono::Utc>",
+            updated_at as "updated_at: chrono::DateTime<chrono::Utc>",
+            total_received,
+            current_pending,
+            current_balance,
+            total_orders,
+            current_orders
+        FROM user_accounts
+        WHERE current_balance > 0 OR current_pending > 0"#
+    )
+    .fetch_all(conn)
+    .await?;
+    Ok(accounts)
+}

--- a/tari_payment_engine/src/sqlite/sqlite_impl.rs
+++ b/tari_payment_engine/src/sqlite/sqlite_impl.rs
@@ -303,6 +303,12 @@ impl AccountManagement for SqliteDatabase {
         let orders = orders::search_orders(query, &mut conn).await?;
         Ok(orders)
     }
+
+    async fn creditors(&self) -> Result<Vec<UserAccount>, AccountApiError> {
+        let mut conn = self.pool.acquire().await?;
+        let accounts = user_accounts::creditors(&mut conn).await?;
+        Ok(accounts)
+    }
 }
 
 impl AuthManagement for SqliteDatabase {

--- a/tari_payment_engine/src/tpe_api/accounts_api.rs
+++ b/tari_payment_engine/src/tpe_api/accounts_api.rs
@@ -91,4 +91,8 @@ where B: AccountManagement
     ) -> Result<Vec<Order>, AccountApiError> {
         self.db.search_orders(query, only_for).await.map_err(|e| AccountApiError::DatabaseError(e.to_string()))
     }
+
+    pub async fn creditors(&self) -> Result<Vec<UserAccount>, AccountApiError> {
+        self.db.creditors().await
+    }
 }

--- a/tari_payment_engine/src/traits/account_management.rs
+++ b/tari_payment_engine/src/traits/account_management.rs
@@ -62,4 +62,6 @@ pub trait AccountManagement {
         query: OrderQueryFilter,
         only_for: Option<TariAddress>,
     ) -> Result<Vec<Order>, AccountApiError>;
+
+    async fn creditors(&self) -> Result<Vec<UserAccount>, AccountApiError>;
 }

--- a/tari_payment_server/src/endpoint_tests/mocks.rs
+++ b/tari_payment_server/src/endpoint_tests/mocks.rs
@@ -20,6 +20,7 @@ mock! {
         async fn history_for_address(&self, address: &TariAddress) -> Result<Option<FullAccount>, AccountApiError>;
         async fn history_for_id(&self, account_id: i64) -> Result<Option<FullAccount>, AccountApiError>;
         async fn search_orders(&self, query: OrderQueryFilter, only_address: Option<TariAddress>) -> Result<Vec<Order>, AccountApiError>;
+        async fn creditors(&self) -> Result<Vec<UserAccount>, AccountApiError>;
     }
 }
 

--- a/tari_payment_server/src/server.rs
+++ b/tari_payment_server/src/server.rs
@@ -30,6 +30,7 @@ use crate::{
         AccountRoute,
         AuthRoute,
         CheckTokenRoute,
+        CreditorsRoute,
         HistoryForAddressRoute,
         HistoryForIdRoute,
         IncomingPaymentNotificationRoute,
@@ -113,6 +114,7 @@ pub fn create_server_instance(
             .service(MyPaymentsRoute::<SqliteDatabase>::new())
             .service(PaymentsRoute::<SqliteDatabase>::new())
             .service(OrdersSearchRoute::<SqliteDatabase>::new())
+            .service(CreditorsRoute::<SqliteDatabase>::new())
             .service(CheckTokenRoute::new());
         let use_x_forwarded_for = config.use_x_forwarded_for;
         let use_forwarded = config.use_forwarded;


### PR DESCRIPTION
The `/api/creditors` endpoint allows admins (with the `ReadAll` role) to query all accounts that have a positive balance (either pending or current) on the system.

This is useful for troubleshooting issues when customers have sent a payment but their orders were not matched.

* Funds might still be in pending and need to be confirmed on the blockchain before the order will be matched. Also check that the hot wallet is sending notifications.
* The current balance is not enough the complete the order. In this case there will be both a current balance and a positive value in current orders (did users take fees into account?)
* In other cases, the order_id and payment were not matched because of an error in the memos. Here you should see a naked current balance, and some additional sleuthing is required to find the order it corresponds to. Once identified, an admin will need to complete a manual order-payment match.