### PR TITLE
feat: attach order

### DIFF
--- a/e2e/tests/features/attach_order_to_address.feature
+++ b/e2e/tests/features/attach_order_to_address.feature
@@ -1,0 +1,64 @@
+# This feature is temporarily disabled
+Feature: Admins can manually attach an order to a wallet address
+  Background:
+    Given a database with some accounts
+    Given some role assignments
+
+  Scenario: Unauthenticated users cannot access the `/attach_order` endpoint
+    When User POSTs to "/api/attach_order" with body
+        """
+        {
+          "order_id": "1",
+          "address": "680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+          "reason": "for the lulz"
+        }
+        """
+    Then I receive a 401 Unauthenticated response with the message 'An error occurred, no cookie containing a jwt was found in the request.'
+
+  Scenario: Standard user cannot access the `/attach_order` endpoint
+    When Alice authenticates with nonce = 1 and roles = "user"
+    When Alice POSTs to "/api/attach_order" with body
+        """
+        {
+          "order_id": "1",
+          "address": "680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+          "reason": "for the lulz"
+        }
+        """
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+  Scenario: Admin user cannot access the `/attach_order` endpoint if he does not ask for 'write' role
+    When Admin authenticates with nonce = 1 and roles = "user,read_all"
+    When Admin POSTs to "/api/attach_order" with body
+        """
+        {
+          "order_id": "1",
+          "address": "680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+          "reason": "You must ask for the WRITE roles, geddit?"
+        }
+        """
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+  Scenario: The Tari address must be valid
+    When Admin authenticates with nonce = 1 and roles = "user,read_all,write"
+    When Admin POSTs to "/api/attach_order" with body
+        """
+        {
+          "order_id": "1",
+          "address": "deadbeefbe13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+          "reason": "That's not a Tari address!"
+        }
+        """
+    Then I receive a 400 BadRequest response with the message 'Cannot recover public key'
+
+  Scenario: An admin can attach an order to a new address.
+    When Admin authenticates with nonce = 1 and roles = "user,read_all,write"
+    When Admin POSTs to "/api/attach_order" with body
+    """
+    {
+          "order_id": "1",
+          "address": "4c827cbd0b9ba38a8659f05969c28d1020d096ba06aed8419fc25c13f1ea9a6e48",
+          "reason": "User moved to new wallet"
+    }
+    """
+    Then I receive a 400 BadRequest response with the message 'This feature is not supported yet'

--- a/tari_payment_engine/src/tpe_api/order_flow_api.rs
+++ b/tari_payment_engine/src/tpe_api/order_flow_api.rs
@@ -1,9 +1,21 @@
 use std::fmt::Debug;
 
 use log::*;
+use tari_common_types::tari_address::TariAddress;
 
 use crate::{
-    db_types::{CreditNote, MicroTari, NewOrder, NewPayment, Order, OrderId, OrderStatusType, Payment, TransferStatus},
+    db_types::{
+        CreditNote,
+        MicroTari,
+        NewOrder,
+        NewPayment,
+        Order,
+        OrderId,
+        OrderStatusType,
+        Payment,
+        TransferStatus,
+        UserAccount,
+    },
     events::{EventProducers, OrderAnnulledEvent, OrderEvent, OrderModifiedEvent, PaymentEvent},
     order_objects::OrderChanged,
     traits::{OrderMovedResult, PaymentGatewayDatabase, PaymentGatewayError},
@@ -372,6 +384,19 @@ where B: PaymentGatewayDatabase
         _new_currency: &str,
     ) -> Result<Order, PaymentGatewayError> {
         Err(PaymentGatewayError::UnsupportedAction("Multiple currencies".to_string()))
+    }
+
+    pub async fn attach_order_to_address(
+        &self,
+        order_id: &OrderId,
+        address: &TariAddress,
+    ) -> Result<UserAccount, PaymentGatewayError> {
+        debug!("🔄️📦️ Attaching order [{order_id}] to address [{address}]");
+        let account = self.db.attach_order_to_address(order_id, address).await?;
+        info!("🔄️📦️ Order [{order_id}] attached to address [{address}]");
+        // todo - hook required here? Nothing existing fits
+        // todo: self.try_pay_order(&account).await?;
+        Ok(account)
     }
 
     pub fn db(&self) -> &B {

--- a/tari_payment_engine/src/traits/payment_gateway_database.rs
+++ b/tari_payment_engine/src/traits/payment_gateway_database.rs
@@ -1,7 +1,19 @@
+use tari_common_types::tari_address::TariAddress;
 use thiserror::Error;
 
 use crate::{
-    db_types::{CreditNote, MicroTari, NewOrder, NewPayment, Order, OrderId, OrderStatusType, Payment, TransferStatus},
+    db_types::{
+        CreditNote,
+        MicroTari,
+        NewOrder,
+        NewPayment,
+        Order,
+        OrderId,
+        OrderStatusType,
+        Payment,
+        TransferStatus,
+        UserAccount,
+    },
     order_objects::OrderChanged,
     traits::{data_objects::OrderMovedResult, AccountApiError, AccountManagement},
 };
@@ -181,6 +193,12 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
     ) -> Result<Order, PaymentGatewayError> {
         Err(PaymentGatewayError::UnsupportedAction("Multiple currencies".to_string()))
     }
+
+    async fn attach_order_to_address(
+        &self,
+        order_id: &OrderId,
+        address: &TariAddress,
+    ) -> Result<UserAccount, PaymentGatewayError>;
 
     /// Closes the database connection.
     async fn close(&mut self) -> Result<(), PaymentGatewayError> {

--- a/tari_payment_server/src/data_objects.rs
+++ b/tari_payment_server/src/data_objects.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 use tari_payment_engine::{
-    db_types::{MicroTari, NewPayment, OrderId, Role},
+    db_types::{MicroTari, NewPayment, OrderId, Role, SerializedTariAddress},
     helpers::WalletSignature,
 };
 
@@ -74,6 +74,14 @@ pub struct UpdatePriceParams {
 pub struct MoveOrderParams {
     pub order_id: OrderId,
     pub new_customer_id: String,
+    // This reason is not stored in the database, but is captured in the logs
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachOrderParams {
+    pub order_id: OrderId,
+    pub address: SerializedTariAddress,
     // This reason is not stored in the database, but is captured in the logs
     pub reason: String,
 }

--- a/tari_payment_server/src/routes.rs
+++ b/tari_payment_server/src/routes.rs
@@ -42,6 +42,7 @@ use crate::{
     auth::{check_login_token_signature, JwtClaims, TokenIssuer},
     config::ProxyConfig,
     data_objects::{
+        AttachOrderParams,
         JsonResponse,
         ModifyOrderParams,
         MoveOrderParams,
@@ -662,6 +663,37 @@ pub async fn reset_order<B: PaymentGatewayDatabase>(
         e
     })?;
     Ok(HttpResponse::Ok().json(updated_order))
+}
+
+route!(attach_order_to_address => Post "/attach_order" impl PaymentGatewayDatabase where requires [Role::Write]);
+/// Attach an order to a Tari address
+///
+/// This endpoint is used to attach an order to a Tari address. This is useful when a user has made an order but
+/// messed up the memo signature. Once support has verified the order, they can override the entry and attach
+/// the order to the correct address.
+///
+/// The address does _not_ have to exist in the database. A new account will be created if the address is not found.
+///
+/// _Note_: This feature is written, but it's not clear how it should be supported. Currently, you _must_ supply a valid
+/// memo signature with the order to prevent spoofing attacks. That signature contains the wallet address.
+/// From there, you can use `reassign_order` to move the order to a different address.
+///
+/// So I'll leave this stub here for now, and once the server is in production, either a use case will present itself,
+/// or we can remove this endpoint.
+pub async fn attach_order_to_address<B: PaymentGatewayDatabase>(
+    body: web::Json<AttachOrderParams>,
+    _api: web::Data<OrderFlowApi<B>>,
+) -> Result<HttpResponse, ServerError> {
+    let AttachOrderParams { order_id, address, reason } = body.into_inner();
+    let address = address.to_address();
+    info!("💻️ Request to attach order {order_id} to address {address}. Reason: {reason}");
+    Err(ServerError::CannotCompleteRequest("This feature is not supported yet.".into()))
+    // info!("💻️ Attaching order {order_id} to address {address}. Reason: {reason}");
+    // let account = api.attach_order_to_address(&order_id, &address).await.map_err(|e| {
+    //     debug!("💻️ Could not attach order. {e}");
+    //     e
+    // })?;
+    // Ok(HttpResponse::Ok().json(account))
 }
 
 //----------------------------------------------   Checkout  ----------------------------------------------------

--- a/tari_payment_server/src/server.rs
+++ b/tari_payment_server/src/server.rs
@@ -28,6 +28,7 @@ use crate::{
     routes::{
         health,
         AccountRoute,
+        AttachOrderToAddressRoute,
         AuthRoute,
         CancelOrderRoute,
         CheckTokenRoute,
@@ -129,6 +130,7 @@ pub fn create_server_instance(
             .service(UpdatePriceRoute::<SqliteDatabase>::new())
             .service(ReassignOrderRoute::<SqliteDatabase>::new())
             .service(ResetOrderRoute::<SqliteDatabase>::new())
+            .service(AttachOrderToAddressRoute::<SqliteDatabase>::new())
             .service(CheckTokenRoute::new());
         let use_x_forwarded_for = config.use_x_forwarded_for;
         let use_forwarded = config.use_forwarded;


### PR DESCRIPTION
Attach an order to a Tari address

This endpoint is used to attach an order to a Tari address. This is useful when a user has made an order but messed up the memo signature. Once support has verified the order, they can override the entry and attach the order to the correct address.

The address does _not_ have to exist in the database. A new account will be created if the address is not found.

_Note_: This feature is written, but it's not clear how it should be supported. Currently, you _must_ supply a valid memo signature with the order to prevent spoofing attacks. That signature contains the wallet address. From there, you can use `reassign_order` to move the order to a different address.

So I'll leave this stub here for now, and once the server is in production, either a use case will present itself, or we can remove this endpoint.