### PR TITLE
feat: shopify hmac authentication

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,10 +3,16 @@
 # The .env file is used to store secrets and other configuration that should not be committed to the repository
 
 TPG_SHOPIFY_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TPG_SHOPIFY_HMAC_CHECKS=1
 RUST_LOG="error,shopify_payment_gateway=trace"
 TPG_HOST=127.0.0.1
 TPG_PORT=4444
 TPG_DATABASE_URL=sqlite://data/tari_store.db
+TPG_SHOPIFY_IP_WHITELIST=
+TPG_USE_X_FORWARDED_FOR=0
+TPG_USE_FORWARDED=0
+TPG_JWT_SIGNING_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TPG_JWT_VERIFICATION_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Development only
 #DATABASE_URL=postgres://postgres:postgres@localhost:5432/shopify_payment_gateway

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb9843d84c775696c37d9a418bbb01b932629d01870722c0f13eb3f95e2536d"
+checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -3824,13 +3824,17 @@ dependencies = [
 name = "tari_payment_server"
 version = "0.1.0"
 dependencies = [
+ "actix-http",
  "actix-jwt-auth-middleware",
  "actix-web",
  "anyhow",
+ "base64 0.13.1",
+ "bytes",
  "chrono",
  "dotenvy",
  "env_logger",
  "futures",
+ "hmac",
  "log",
  "mockall",
  "paste",
@@ -3838,6 +3842,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "tari-jwt",
  "tari_common_types",
  "tari_payment_engine",

--- a/e2e/tests/cucumber/steps.rs
+++ b/e2e/tests/cucumber/steps.rs
@@ -244,7 +244,8 @@ async fn place_order(
             order.currency = "XTR".to_string();
             order.total_price = MicroTari::from_tari(amount).value().to_string();
             order.user_id = Some(user);
-            order.email = email;
+            order.email = Some(email);
+            order.customer.id = user;
             let order = serde_json::to_string(&order).expect("Failed to serialize order");
             req.body(order).header("Content-Type", "application/json")
         })

--- a/e2e/tests/cucumber/world.rs
+++ b/e2e/tests/cucumber/world.rs
@@ -17,6 +17,7 @@ use tari_payment_engine::{
 };
 use tari_payment_server::{
     config::{AuthConfig, ServerConfig},
+    helpers::Secret,
     server::create_server_instance,
 };
 
@@ -47,6 +48,8 @@ impl Default for TPGWorld {
             host: "127.0.0.1".into(),
             port: 20000 + rand::random::<u16>() % 10_000,
             shopify_api_key: String::default(),
+            shopify_api_secret: Secret::default(),
+            shopify_hmac_checks: false,
             database_url: url.clone(),
             auth: AuthConfig::default(),
             shopify_whitelist: None,

--- a/e2e/tests/features/credit_note.feature
+++ b/e2e/tests/features/credit_note.feature
@@ -43,13 +43,13 @@ Feature: Admins can issue credit notes
     When Admin POSTs to "/api/credit" with body
         """
         {
-          "customer_id": "eric101",
+          "customer_id": "1024",
           "amount": 1000000000,
           "reason": "Grand prize winner"
         }
         """
     Then I receive a 200 OK response with the message "[]"
-    Then account for customer eric101 has a current balance of 1000 Tari
+    Then account for customer 1024 has a current balance of 1000 Tari
     # Eric places an order from his wallet with these credentials:
     # Secret key: 9b72bd6f55466f693c71f4a5abeb0767c4c080cc4752d336b6c0381e2dee5b01
     # Public key: ecf774d7f185295b9c2b1f87072919d4e5bd1e280697b172a0db91f7caebd364
@@ -62,7 +62,7 @@ Feature: Admins can issue credit notes
       "signature":"4e53a8ded2b424334de6e12e70f7f0b61dd4ad3a66a06aacdf4553dcf0e2f63fa9639f93df6065ad228094f1fbe50b447bed1d7324cc4e0a2093e8bbf475350c"}
     """
     Then order "order1024:1" is in state Paid
-    Then account for customer eric101 has a current balance of 750 Tari
+    Then account for customer 1024 has a current balance of 750 Tari
 
   Scenario: An admin can issue a credit note for a customer id that has a pending order, and the order will be filled
     When Admin authenticates with nonce = 1 and roles = "write"

--- a/e2e/tests/features/order_payment_matching.feature
+++ b/e2e/tests/features/order_payment_matching.feature
@@ -58,7 +58,7 @@ Feature: Order Fulfillment
     {
       "order": {
       "order_id": "alice001",
-      "customer_id": "alice",
+      "customer_id": "1",
       "total_price": 2400000000,
       "currency": "XTR",
       "id": 1,
@@ -134,7 +134,7 @@ Feature: Order Fulfillment
     {
       "order": {
         "order_id": "alice001",
-        "customer_id": "alice",
+        "customer_id": "1",
         "total_price": 2400000000,
         "currency": "XTR",
         "id": 1,
@@ -218,7 +218,7 @@ Feature: Order Fulfillment
        "signature":"86267d7373487427e0ea7af57ac2201e6b7d553faef34d701b3a2277fde54135fd5b7b073dfc8ba4a3b90589f3719c267c6b27957f18c4bfa31a31cc7f6a9a06"
     }
     """
-    Then account for customer anon has a current balance of 1 Tari
+    Then account for customer 3 has a current balance of 1 Tari
     And order "anon0001" is in state Paid
     When Customer #1 ["alice"] places order "alice0002" for 3600 XTR, with memo
     """

--- a/tari_payment_server/Cargo.toml
+++ b/tari_payment_server/Cargo.toml
@@ -12,6 +12,7 @@ tari-jwt = {  version = "0.1.0", git = "https://github.com/tari-project/tari-jwt
 tari_payment_engine = { version = "0.1.0", path = "../tari_payment_engine" }
 
 actix-jwt-auth-middleware = { version = "0.5.0", git = "https://github.com/cjs77/actix-jwt-auth-middleware.git", branch = "master" }
+actix-http = "3.8.0"
 actix-web = "4.0.0-beta.8"
 chrono = { version = "0.4.31", features = ["serde"] }
 dotenvy = "0.15.0"
@@ -26,6 +27,10 @@ thiserror = "1.0.32"
 tokio = { version = "1.20.1", features = ["full"] }
 futures = "0.3.30"
 regex = "1.10.4"
+sha2 = "0.10.8"
+base64 = "0.13.1"
+hmac = "0.12.1"
+bytes = "1.6.0"
 
 [dev-dependencies]
 anyhow = "1.0.81"

--- a/tari_payment_server/src/middleware/hmac.rs
+++ b/tari_payment_server/src/middleware/hmac.rs
@@ -1,0 +1,120 @@
+//! HMAC middleware for Actix Web.
+//!
+//! This module provides a middleware for Actix Web that checks the HMAC signature of incoming requests.
+//!
+//! Shopify sends a HMAC signature in the headers of the request, using the `TPG_SHOPIFY_ADMIN_ACCESS_TOKEN` as the
+//! secret key, and the body of the request as the data to sign.
+//!
+//! The HMAC is provided in the `X-Shopify-Hmac-SHA256` header.
+//!
+//! You can use this middleware to verify the HMAC signature of incoming requests by wrapping all shopify webhook
+//! calls with this middleware.
+
+use std::{
+    future::{ready, Ready},
+    rc::Rc,
+};
+
+use actix_http::h1;
+use actix_web::{
+    dev::{forward_ready, Payload, Service, ServiceRequest, ServiceResponse, Transform},
+    error::{ErrorBadRequest, ErrorForbidden},
+    web,
+    Error,
+};
+use futures::future::LocalBoxFuture;
+use log::{trace, warn};
+
+use crate::helpers::{calculate_hmac, Secret};
+
+pub struct HmacMiddlewareFactory {
+    hmac_header: String,
+    key: Secret<String>,
+    // If false, then the middleware will not check the HMAC signature and always allow the call
+    enabled: bool,
+}
+
+impl HmacMiddlewareFactory {
+    pub fn new(hmac_header: &str, key: Secret<String>, enabled: bool) -> Self {
+        HmacMiddlewareFactory { hmac_header: hmac_header.into(), key, enabled }
+    }
+}
+
+impl<S, B> Transform<S, ServiceRequest> for HmacMiddlewareFactory
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Error = Error;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+    type InitError = ();
+    type Response = ServiceResponse<B>;
+    type Transform = HmacMiddlewareService<S>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(HmacMiddlewareService {
+            hmac_header: self.hmac_header.clone(),
+            key: self.key.clone(),
+            enabled: self.enabled,
+            service: Rc::new(service),
+        }))
+    }
+}
+
+pub struct HmacMiddlewareService<S> {
+    hmac_header: String,
+    key: Secret<String>,
+    enabled: bool,
+    service: Rc<S>,
+}
+
+impl<S, B> Service<ServiceRequest> for HmacMiddlewareService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Response = ServiceResponse<B>;
+
+    forward_ready!(service);
+
+    fn call(&self, mut req: ServiceRequest) -> Self::Future {
+        let service = Rc::clone(&self.service);
+        let secret = self.key.reveal().clone();
+        let hmac_header = self.hmac_header.clone();
+        let enabled = self.enabled;
+        Box::pin(async move {
+            trace!("🔐️ Checking HMAC for request");
+            if !enabled {
+                trace!("HMAC checks are disabled. Allowing request.");
+                return service.call(req).await;
+            }
+            let data = req.extract::<web::Bytes>().await.map_err(|e| {
+                warn!("Failed to extract request data: {:?}", e);
+                ErrorBadRequest("Failed to extract request data.")
+            })?;
+            let hmac_calc = calculate_hmac(&secret, data.as_ref());
+            let hmac = req.headers().get(&hmac_header).ok_or_else(|| {
+                warn!("No HMAC signature found in request. denying access.");
+                ErrorForbidden("No HMAC signature found.")
+            })?;
+            let validated = hmac == hmac_calc.as_str();
+            if validated {
+                req.set_payload(bytes_to_payload(data));
+                service.call(req).await
+            } else {
+                warn!("Invalid HMAC signature found in request. denying access.");
+                Err(ErrorForbidden("Invalid HMAC signature."))
+            }
+        })
+    }
+}
+
+fn bytes_to_payload(buf: web::Bytes) -> Payload {
+    let (_, mut pl) = h1::Payload::create(true);
+    pl.unread_data(buf);
+    Payload::from(pl)
+}

--- a/tari_payment_server/src/middleware/mod.rs
+++ b/tari_payment_server/src/middleware/mod.rs
@@ -1,3 +1,5 @@
 mod acl;
+mod hmac;
 
 pub use acl::{AclMiddlewareFactory, AclMiddlewareService};
+pub use hmac::{HmacMiddlewareFactory, HmacMiddlewareService};

--- a/tari_payment_server/src/test_assets/actual_order.json
+++ b/tari_payment_server/src/test_assets/actual_order.json
@@ -1,0 +1,359 @@
+{
+  "id": 5621163655380,
+  "admin_graphql_api_id": "gid://shopify/Order/5621163655380",
+  "app_id": 580111,
+  "browser_ip": "94.63.235.150",
+  "buyer_accepts_marketing": false,
+  "cancel_reason": null,
+  "cancelled_at": null,
+  "cart_token": "Z2NwLWV1cm9wZS13ZXN0MTowMUowUVlFVjNYMTZBMENBSE1ETkZDWDVCTg",
+  "checkout_id": 36496227336404,
+  "checkout_token": "defd7b7d98351052e3095b04320c94ec",
+  "client_details": {
+    "accept_language": "en-US",
+    "browser_height": null,
+    "browser_ip": "94.63.235.150",
+    "browser_width": null,
+    "session_hash": null,
+    "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0"
+  },
+  "closed_at": null,
+  "confirmation_number": "PAL4D6QRK",
+  "confirmed": true,
+  "created_at": "2024-06-19T18:00:55+01:00",
+  "currency": "USD",
+  "current_subtotal_price": "19.00",
+  "current_subtotal_price_set": {
+    "shop_money": {
+      "amount": "19.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "19.00",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_additional_fees_set": null,
+  "current_total_discounts": "0.00",
+  "current_total_discounts_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_duties_set": null,
+  "current_total_price": "23.90",
+  "current_total_price_set": {
+    "shop_money": {
+      "amount": "23.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "23.90",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_tax": "0.00",
+  "current_total_tax_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "customer_locale": "en-US",
+  "device_id": null,
+  "discount_codes": [],
+  "estimated_taxes": false,
+  "financial_status": "pending",
+  "fulfillment_status": null,
+  "landing_site": "/password",
+  "landing_site_ref": null,
+  "location_id": null,
+  "merchant_of_record_app_id": null,
+  "name": "#1002",
+  "note": "{\r\n\"auth\": {},\r\n\"foo\": {}\r\n}",
+  "note_attributes": [],
+  "number": 2,
+  "order_number": 1002,
+  "original_total_additional_fees_set": null,
+  "original_total_duties_set": null,
+  "payment_gateway_names": [
+    "Tari Payment Server"
+  ],
+  "po_number": null,
+  "presentment_currency": "USD",
+  "processed_at": "2024-06-19T18:00:53+01:00",
+  "reference": "d61ec59dc4ecb73e9466ff7ad5272245",
+  "referring_site": "",
+  "source_identifier": "d61ec59dc4ecb73e9466ff7ad5272245",
+  "source_name": "web",
+  "source_url": null,
+  "subtotal_price": "19.00",
+  "subtotal_price_set": {
+    "shop_money": {
+      "amount": "19.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "19.00",
+      "currency_code": "USD"
+    }
+  },
+  "tags": "",
+  "tax_exempt": false,
+  "tax_lines": [],
+  "taxes_included": false,
+  "test": false,
+  "token": "ec4d579760422620bfe910b96b59a32f",
+  "total_discounts": "0.00",
+  "total_discounts_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_line_items_price": "19.00",
+  "total_line_items_price_set": {
+    "shop_money": {
+      "amount": "19.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "19.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_outstanding": "23.90",
+  "total_price": "23.90",
+  "total_price_set": {
+    "shop_money": {
+      "amount": "23.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "23.90",
+      "currency_code": "USD"
+    }
+  },
+  "total_shipping_price_set": {
+    "shop_money": {
+      "amount": "4.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "4.90",
+      "currency_code": "USD"
+    }
+  },
+  "total_tax": "0.00",
+  "total_tax_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_tip_received": "0.00",
+  "total_weight": 498,
+  "updated_at": "2024-06-19T18:00:56+01:00",
+  "user_id": null,
+  "billing_address": {
+    "province": "New York",
+    "country": "United States",
+    "country_code": "US",
+    "province_code": "NY"
+  },
+  "customer": {
+    "id": 7345051926740,
+    "created_at": "2024-06-19T15:46:02+01:00",
+    "updated_at": "2024-06-19T18:00:55+01:00",
+    "state": "disabled",
+    "note": null,
+    "verified_email": true,
+    "multipass_identifier": null,
+    "tax_exempt": false,
+    "email_marketing_consent": null,
+    "sms_marketing_consent": {
+      "state": "not_subscribed",
+      "opt_in_level": "single_opt_in",
+      "consent_updated_at": null,
+      "consent_collected_from": "SHOPIFY"
+    },
+    "tags": "",
+    "currency": "USD",
+    "tax_exemptions": [],
+    "admin_graphql_api_id": "gid://shopify/Customer/7345051926740",
+    "default_address": {
+      "id": 8919770628308,
+      "customer_id": 7345051926740,
+      "company": null,
+      "province": "New York",
+      "country": "United States",
+      "province_code": "NY",
+      "country_code": "US",
+      "country_name": "United States",
+      "default": true
+    }
+  },
+  "discount_applications": [],
+  "fulfillments": [],
+  "line_items": [
+    {
+      "id": 13868618744020,
+      "admin_graphql_api_id": "gid://shopify/LineItem/13868618744020",
+      "attributed_staffs": [],
+      "current_quantity": 1,
+      "fulfillable_quantity": 1,
+      "fulfillment_service": "manual",
+      "fulfillment_status": null,
+      "gift_card": false,
+      "grams": 340,
+      "name": "Totally Secure Moleskine® Notebook",
+      "price": "11.00",
+      "price_set": {
+        "shop_money": {
+          "amount": "11.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "11.00",
+          "currency_code": "USD"
+        }
+      },
+      "product_exists": true,
+      "product_id": 8494448771284,
+      "properties": [],
+      "quantity": 1,
+      "requires_shipping": true,
+      "sku": "TARI_NOTEBOOK1",
+      "taxable": false,
+      "title": "Totally Secure Moleskine® Notebook",
+      "total_discount": "0.00",
+      "total_discount_set": {
+        "shop_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        }
+      },
+      "variant_id": 45280616054996,
+      "variant_inventory_management": "shopify",
+      "variant_title": null,
+      "vendor": "The TTL Store",
+      "tax_lines": [],
+      "duties": [],
+      "discount_allocations": []
+    },
+    {
+      "id": 13868618776788,
+      "admin_graphql_api_id": "gid://shopify/LineItem/13868618776788",
+      "attributed_staffs": [],
+      "current_quantity": 1,
+      "fulfillable_quantity": 1,
+      "fulfillment_service": "manual",
+      "fulfillment_status": null,
+      "gift_card": false,
+      "grams": 159,
+      "name": "Fashion Forward Socks",
+      "price": "8.00",
+      "price_set": {
+        "shop_money": {
+          "amount": "8.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "8.00",
+          "currency_code": "USD"
+        }
+      },
+      "product_exists": true,
+      "product_id": 8494449066196,
+      "properties": [],
+      "quantity": 1,
+      "requires_shipping": true,
+      "sku": "TARI_LOGOSOCKS",
+      "taxable": true,
+      "title": "Fashion Forward Socks",
+      "total_discount": "0.00",
+      "total_discount_set": {
+        "shop_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        }
+      },
+      "variant_id": 45280616513748,
+      "variant_inventory_management": "shopify",
+      "variant_title": null,
+      "vendor": "The TTL Store",
+      "tax_lines": [],
+      "duties": [],
+      "discount_allocations": []
+    }
+  ],
+  "payment_terms": null,
+  "refunds": [],
+  "shipping_address": {
+    "province": "New York",
+    "country": "United States",
+    "country_code": "US",
+    "province_code": "NY"
+  },
+  "shipping_lines": [
+    {
+      "id": 4545027571924,
+      "carrier_identifier": "650f1a14fa979ec5c74d063e968411d4",
+      "code": "Economy",
+      "discounted_price": "4.90",
+      "discounted_price_set": {
+        "shop_money": {
+          "amount": "4.90",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "4.90",
+          "currency_code": "USD"
+        }
+      },
+      "is_removed": false,
+      "phone": null,
+      "price": "4.90",
+      "price_set": {
+        "shop_money": {
+          "amount": "4.90",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "4.90",
+          "currency_code": "USD"
+        }
+      },
+      "requested_fulfillment_service_id": null,
+      "source": "shopify",
+      "title": "Economy",
+      "tax_lines": [],
+      "discount_allocations": []
+    }
+  ]
+}

--- a/tari_payment_server/src/test_assets/actual_order2.json
+++ b/tari_payment_server/src/test_assets/actual_order2.json
@@ -1,0 +1,309 @@
+{
+  "id": 5621189509332,
+  "admin_graphql_api_id": "gid://shopify/Order/5621189509332",
+  "app_id": 580111,
+  "browser_ip": "94.63.235.150",
+  "buyer_accepts_marketing": false,
+  "cancel_reason": null,
+  "cancelled_at": null,
+  "cart_token": "Z2NwLWV1cm9wZS13ZXN0MTowMUowUlJIN1dTSEoyNURFM1M1U05NSjlLUg",
+  "checkout_id": 36497036214484,
+  "checkout_token": "fb5df8f4899923136c762fb7d55bd4bf",
+  "client_details": {
+    "accept_language": "en-US",
+    "browser_height": null,
+    "browser_ip": "94.63.235.150",
+    "browser_width": null,
+    "session_hash": null,
+    "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0"
+  },
+  "closed_at": null,
+  "confirmation_number": "RQ50HVD85",
+  "confirmed": true,
+  "created_at": "2024-06-19T18:29:13+01:00",
+  "currency": "USD",
+  "current_subtotal_price": "24.00",
+  "current_subtotal_price_set": {
+    "shop_money": {
+      "amount": "24.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "24.00",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_additional_fees_set": null,
+  "current_total_discounts": "0.00",
+  "current_total_discounts_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_duties_set": null,
+  "current_total_price": "28.90",
+  "current_total_price_set": {
+    "shop_money": {
+      "amount": "28.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "28.90",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_tax": "0.00",
+  "current_total_tax_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "customer_locale": "en-US",
+  "device_id": null,
+  "discount_codes": [],
+  "estimated_taxes": false,
+  "financial_status": "pending",
+  "fulfillment_status": null,
+  "landing_site": "/password",
+  "landing_site_ref": null,
+  "location_id": null,
+  "merchant_of_record_app_id": null,
+  "name": "#1003",
+  "note": "{\"address\":\"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d\",\"order_id\":\"order1001\",\"signature\":\"ae26f3139d6505bfe28452ddd00e76ba04354114959ea95e7248a13cd673d02288e3e42f416dc42cc51ecca8bf6b44a2819cfcd4f2507c6ec9af9c92621ffa0c\"}",
+  "note_attributes": [],
+  "number": 3,
+  "order_number": 1003,
+  "original_total_additional_fees_set": null,
+  "original_total_duties_set": null,
+  "payment_gateway_names": [
+    "Tari Payment Server"
+  ],
+  "po_number": null,
+  "presentment_currency": "USD",
+  "processed_at": "2024-06-19T18:29:11+01:00",
+  "reference": "89195f12161a3ce821463e209e6d7455",
+  "referring_site": "",
+  "source_identifier": "89195f12161a3ce821463e209e6d7455",
+  "source_name": "web",
+  "source_url": null,
+  "subtotal_price": "24.00",
+  "subtotal_price_set": {
+    "shop_money": {
+      "amount": "24.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "24.00",
+      "currency_code": "USD"
+    }
+  },
+  "tags": "",
+  "tax_exempt": false,
+  "tax_lines": [],
+  "taxes_included": false,
+  "test": false,
+  "token": "5d3c5d2ffe01ea89bb1690bdfc537cb7",
+  "total_discounts": "0.00",
+  "total_discounts_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_line_items_price": "24.00",
+  "total_line_items_price_set": {
+    "shop_money": {
+      "amount": "24.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "24.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_outstanding": "28.90",
+  "total_price": "28.90",
+  "total_price_set": {
+    "shop_money": {
+      "amount": "28.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "28.90",
+      "currency_code": "USD"
+    }
+  },
+  "total_shipping_price_set": {
+    "shop_money": {
+      "amount": "4.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "4.90",
+      "currency_code": "USD"
+    }
+  },
+  "total_tax": "0.00",
+  "total_tax_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_tip_received": "0.00",
+  "total_weight": 474,
+  "updated_at": "2024-06-19T18:29:14+01:00",
+  "user_id": null,
+  "billing_address": {
+    "province": "Tennessee",
+    "country": "United States",
+    "country_code": "US",
+    "province_code": "TN"
+  },
+  "customer": {
+    "id": 7345180737748,
+    "created_at": "2024-06-19T18:29:11+01:00",
+    "updated_at": "2024-06-19T18:29:14+01:00",
+    "state": "disabled",
+    "note": null,
+    "verified_email": true,
+    "multipass_identifier": null,
+    "tax_exempt": false,
+    "email_marketing_consent": {
+      "state": "not_subscribed",
+      "opt_in_level": "single_opt_in",
+      "consent_updated_at": null
+    },
+    "sms_marketing_consent": null,
+    "tags": "",
+    "currency": "USD",
+    "tax_exemptions": [],
+    "admin_graphql_api_id": "gid://shopify/Customer/7345180737748",
+    "default_address": {
+      "id": 8919793270996,
+      "customer_id": 7345180737748,
+      "company": null,
+      "province": "Tennessee",
+      "country": "United States",
+      "province_code": "TN",
+      "country_code": "US",
+      "country_name": "United States",
+      "default": true
+    }
+  },
+  "discount_applications": [],
+  "fulfillments": [],
+  "line_items": [
+    {
+      "id": 13868670189780,
+      "admin_graphql_api_id": "gid://shopify/LineItem/13868670189780",
+      "attributed_staffs": [],
+      "current_quantity": 3,
+      "fulfillable_quantity": 3,
+      "fulfillment_service": "manual",
+      "fulfillment_status": null,
+      "gift_card": false,
+      "grams": 159,
+      "name": "Fashion Forward Socks",
+      "price": "8.00",
+      "price_set": {
+        "shop_money": {
+          "amount": "8.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "8.00",
+          "currency_code": "USD"
+        }
+      },
+      "product_exists": true,
+      "product_id": 8494449066196,
+      "properties": [],
+      "quantity": 3,
+      "requires_shipping": true,
+      "sku": "TARI_LOGOSOCKS",
+      "taxable": true,
+      "title": "Fashion Forward Socks",
+      "total_discount": "0.00",
+      "total_discount_set": {
+        "shop_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        }
+      },
+      "variant_id": 45280616513748,
+      "variant_inventory_management": "shopify",
+      "variant_title": null,
+      "vendor": "The TTL Store",
+      "tax_lines": [],
+      "duties": [],
+      "discount_allocations": []
+    }
+  ],
+  "payment_terms": null,
+  "refunds": [],
+  "shipping_address": {
+    "province": "Tennessee",
+    "country": "United States",
+    "country_code": "US",
+    "province_code": "TN"
+  },
+  "shipping_lines": [
+    {
+      "id": 4545044185300,
+      "carrier_identifier": "650f1a14fa979ec5c74d063e968411d4",
+      "code": "Economy",
+      "discounted_price": "4.90",
+      "discounted_price_set": {
+        "shop_money": {
+          "amount": "4.90",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "4.90",
+          "currency_code": "USD"
+        }
+      },
+      "is_removed": false,
+      "phone": null,
+      "price": "4.90",
+      "price_set": {
+        "shop_money": {
+          "amount": "4.90",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "4.90",
+          "currency_code": "USD"
+        }
+      },
+      "requested_fulfillment_service_id": null,
+      "source": "shopify",
+      "title": "Economy",
+      "tax_lines": [],
+      "discount_allocations": []
+    }
+  ]
+}

--- a/tari_payment_server/src/test_assets/new_order.json
+++ b/tari_payment_server/src/test_assets/new_order.json
@@ -1,188 +1,358 @@
 {
-  "id": 981820079255243500,
-  "token": "123123123",
-  "cart_token": "eeafa272cebfd4b22385bc4b645e762c",
-  "email": "example@email.com",
-  "gateway": null,
-  "buyer_accepts_marketing": false,
-  "created_at": "2022-12-13T13:53:06-05:00",
-  "updated_at": "2022-12-13T13:53:06-05:00",
-  "landing_site": null,
+  "id": 5714720719169,
+  "admin_graphql_api_id": "gid://shopify/Order/5714720719169",
+  "app_id": 580111,
+  "browser_ip": "176.203.83.119",
+  "buyer_accepts_marketing": true,
+  "cancel_reason": null,
+  "cancelled_at": null,
+  "cart_token": "Z2NwLWFzaWEtc291dGhlYXN0MTowMUhRNTFHQjVHODlWVjczWFhLOTdZWUQ0Sw",
+  "checkout_id": 37275602878785,
+  "checkout_token": "90e13fca5bf1958dc1bbc0866902023e",
+  "client_details": {
+    "accept_language": "en-QA",
+    "browser_height": null,
+    "browser_ip": "176.203.83.119",
+    "browser_width": null,
+    "session_hash": null,
+    "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_2_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1"
+  },
+  "closed_at": null,
+  "confirmed": true,
+  "contact_email": "maaak1997@gmail.com",
+  "created_at": "2024-02-21T08:42:27+03:00",
+  "currency": "QAR",
+  "current_subtotal_price": "160.00",
+  "current_subtotal_price_set": {
+    "shop_money": {
+      "amount": "160.00",
+      "currency_code": "QAR"
+    },
+    "presentment_money": {
+      "amount": "160.00",
+      "currency_code": "QAR"
+    }
+  },
+  "current_total_additional_fees_set": null,
+  "current_total_discounts": "0.00",
+  "current_total_discounts_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "QAR"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "QAR"
+    }
+  },
+  "current_total_duties_set": null,
+  "current_total_price": "190.00",
+  "current_total_price_set": {
+    "shop_money": {
+      "amount": "190.00",
+      "currency_code": "QAR"
+    },
+    "presentment_money": {
+      "amount": "190.00",
+      "currency_code": "QAR"
+    }
+  },
+  "current_total_tax": "0.00",
+  "current_total_tax_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "QAR"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "QAR"
+    }
+  },
+  "customer_locale": "en-QA",
+  "device_id": null,
+  "discount_codes": [],
+  "email": "maaak1997@gmail.com",
+  "estimated_taxes": false,
+  "financial_status": "pending",
+  "fulfillment_status": null,
+  "landing_site": "/collections/greeting-envelopes-cards/products/envelopes-cards-ye76",
+  "landing_site_ref": null,
+  "location_id": null,
+  "merchant_of_record_app_id": null,
+  "name": "#1318",
   "note": null,
   "note_attributes": [],
-  "referring_site": null,
-  "shipping_lines": [],
-  "taxes_included": false,
-  "total_weight": 907,
-  "currency": "USD",
-  "completed_at": null,
-  "closed_at": null,
-  "user_id": null,
-  "location_id": null,
-  "source_identifier": null,
-  "source_url": null,
-  "device_id": null,
-  "phone": null,
-  "customer_locale": null,
-  "line_items": [
-    {
-      "applied_discounts": [],
-      "discount_allocations": [],
-      "key": "778a301838998bcdbae2ff836d0d3b49",
-      "destination_location_id": 938998177,
-      "fulfillment_service": "manual",
-      "gift_card": false,
-      "grams": 454,
-      "origin_location_id": 938998176,
-      "presentment_title": "IPod Nano - 8GB",
-      "presentment_variant_title": "",
-      "product_id": 632910392,
-      "properties": null,
-      "quantity": 1,
-      "requires_shipping": true,
-      "sku": "IPOD2008PINK",
-      "tax_lines": [],
-      "taxable": true,
-      "title": "IPod Nano - 8GB",
-      "variant_id": null,
-      "variant_title": "",
-      "variant_price": null,
-      "vendor": "Apple",
-      "user_id": null,
-      "unit_price_measurement": null,
-      "rank": null,
-      "compare_at_price": null,
-      "line_price": "199.00",
-      "price": "199.00"
-    },
-    {
-      "applied_discounts": [],
-      "discount_allocations": [],
-      "key": "778a301838998bcdbae2ff836d0d3b49",
-      "destination_location_id": 938998177,
-      "fulfillment_service": "manual",
-      "gift_card": false,
-      "grams": 454,
-      "origin_location_id": 938998176,
-      "presentment_title": "IPod Nano - 8GB",
-      "presentment_variant_title": "",
-      "product_id": 632910392,
-      "properties": null,
-      "quantity": 1,
-      "requires_shipping": true,
-      "sku": "IPOD2008PINK",
-      "tax_lines": [],
-      "taxable": true,
-      "title": "IPod Nano - 8GB",
-      "variant_id": null,
-      "variant_title": "",
-      "variant_price": null,
-      "vendor": "Apple",
-      "user_id": null,
-      "unit_price_measurement": null,
-      "rank": null,
-      "compare_at_price": null,
-      "line_price": "199.00",
-      "price": "199.00"
-    }
+  "number": 318,
+  "order_number": 1318,
+  "order_status_url": "https://pixels.qa/81084612929/orders/04eaa913ca3ccc9c99603a5921a1268d/authenticate?key=8a84877a458b8039ce3c39eee46bec53",
+  "original_total_additional_fees_set": null,
+  "original_total_duties_set": null,
+  "payment_gateway_names": [
+    "Cash on Delivery (COD)"
   ],
-  "name": "#981820079255243537",
-  "source": null,
-  "abandoned_checkout_url": "https:\/\/checkout.local\/548380009\/checkouts\/123123123\/recover?key=example-secret-token",
-  "discount_codes": [],
-  "tax_lines": [],
+  "phone": null,
+  "presentment_currency": "QAR",
+  "processed_at": "2024-02-21T08:42:23+03:00",
+  "reference": "089594e1bf22f3f304f90c8762b838f5",
+  "referring_site": "https://pixels.qa/collections/greeting-envelopes-cards?page=6",
+  "source_identifier": "089594e1bf22f3f304f90c8762b838f5",
   "source_name": "web",
-  "presentment_currency": "USD",
-  "buyer_accepts_sms_marketing": false,
-  "sms_marketing_phone": null,
-  "total_discounts": "0.00",
-  "total_line_items_price": "398.00",
-  "total_price": "398.00",
-  "total_tax": "0.00",
-  "subtotal_price": "398.00",
-  "total_duties": null,
-  "billing_address": {
-    "first_name": "Bob",
-    "address1": "123 Billing Street",
-    "phone": "555-555-BILL",
-    "city": "Billtown",
-    "zip": "K2P0B0",
-    "province": "Kentucky",
-    "country": "United States",
-    "last_name": "Biller",
-    "address2": null,
-    "company": "My Company",
-    "latitude": null,
-    "longitude": null,
-    "name": "Bob Biller",
-    "country_code": "US",
-    "province_code": "KY"
+  "source_url": null,
+  "subtotal_price": "160.00",
+  "subtotal_price_set": {
+    "shop_money": {
+      "amount": "160.00",
+      "currency_code": "QAR"
+    },
+    "presentment_money": {
+      "amount": "160.00",
+      "currency_code": "QAR"
+    }
   },
-  "shipping_address": {
-    "first_name": "Steve",
-    "address1": "123 Shipping Street",
-    "phone": "555-555-SHIP",
-    "city": "Shippington",
-    "zip": "K2P0S0",
-    "province": "Kentucky",
-    "country": "United States",
-    "last_name": "Shipper",
+  "tags": "",
+  "tax_lines": [],
+  "taxes_included": false,
+  "test": false,
+  "token": "04eaa913ca3ccc9c99603a5921a1268d",
+  "total_discounts": "0.00",
+  "total_discounts_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "QAR"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "QAR"
+    }
+  },
+  "total_line_items_price": "160.00",
+  "total_line_items_price_set": {
+    "shop_money": {
+      "amount": "160.00",
+      "currency_code": "QAR"
+    },
+    "presentment_money": {
+      "amount": "160.00",
+      "currency_code": "QAR"
+    }
+  },
+  "total_outstanding": "190.00",
+  "total_price": "190.00",
+  "total_price_set": {
+    "shop_money": {
+      "amount": "190.00",
+      "currency_code": "QAR"
+    },
+    "presentment_money": {
+      "amount": "190.00",
+      "currency_code": "QAR"
+    }
+  },
+  "total_shipping_price_set": {
+    "shop_money": {
+      "amount": "30.00",
+      "currency_code": "QAR"
+    },
+    "presentment_money": {
+      "amount": "30.00",
+      "currency_code": "QAR"
+    }
+  },
+  "total_tax": "0.00",
+  "total_tax_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "QAR"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "QAR"
+    }
+  },
+  "total_tip_received": "0.00",
+  "total_weight": 0,
+  "updated_at": "2024-02-21T08:42:29+03:00",
+  "user_id": null,
+  "billing_address": {
+    "first_name": "Meme",
+    "address1": "Zone 53 Almearad, street 1215, home 23",
+    "phone": "60097002",
+    "city": "Alwajba",
+    "zip": null,
+    "province": null,
+    "country": "Qatar",
+    "last_name": "Alshamari",
     "address2": null,
-    "company": "Shipping Company",
+    "company": null,
     "latitude": null,
     "longitude": null,
-    "name": "Steve Shipper",
-    "country_code": "US",
-    "province_code": "KY"
+    "name": "Meme Alshamari",
+    "country_code": "QA",
+    "province_code": null
   },
   "customer": {
-    "id": 603851970716743400,
-    "email": "john@example.com",
-    "accepts_marketing": false,
-    "created_at": null,
-    "updated_at": null,
-    "first_name": "John",
-    "last_name": "Smith",
-    "orders_count": 0,
+    "id": 7806520164673,
+    "email": "maaak1997@gmail.com",
+    "created_at": "2024-02-21T08:27:36+03:00",
+    "updated_at": "2024-02-21T08:42:28+03:00",
+    "first_name": "Meme",
+    "last_name": "Alshamari",
     "state": "disabled",
-    "total_spent": "0.00",
-    "last_order_id": null,
     "note": null,
     "verified_email": true,
     "multipass_identifier": null,
     "tax_exempt": false,
-    "tags": "",
-    "last_order_name": null,
-    "currency": "USD",
     "phone": null,
-    "accepts_marketing_updated_at": null,
-    "marketing_opt_in_level": null,
-    "tax_exemptions": [],
     "email_marketing_consent": {
-      "state": "not_subscribed",
-      "opt_in_level": null,
-      "consent_updated_at": null
+      "state": "subscribed",
+      "opt_in_level": "single_opt_in",
+      "consent_updated_at": "2024-02-21T08:27:36+03:00"
     },
     "sms_marketing_consent": null,
-    "admin_graphql_api_id": "gid:\/\/shopify\/Customer\/603851970716743426",
+    "tags": "",
+    "currency": "QAR",
+    "accepts_marketing": true,
+    "accepts_marketing_updated_at": "2024-02-21T08:27:36+03:00",
+    "marketing_opt_in_level": "single_opt_in",
+    "tax_exemptions": [],
+    "admin_graphql_api_id": "gid://shopify/Customer/7806520164673",
     "default_address": {
-      "id": null,
-      "customer_id": 603851970716743400,
-      "first_name": null,
-      "last_name": null,
+      "id": 9874794774849,
+      "customer_id": 7806520164673,
+      "first_name": "Meme",
+      "last_name": "Alshamari",
       "company": null,
-      "address1": "123 Elm St.",
+      "address1": "Zone 53 Almearad, street 1215, home 23",
       "address2": null,
-      "city": "Ottawa",
-      "province": "Ontario",
-      "country": "Canada",
-      "zip": "K2H7A8",
-      "phone": "123-123-1234",
-      "name": "",
-      "province_code": "ON",
-      "country_code": "CA",
-      "country_name": "Canada",
+      "city": "Alwajba",
+      "province": null,
+      "country": "Qatar",
+      "zip": null,
+      "phone": "60097002",
+      "name": "Meme Alshamari",
+      "province_code": null,
+      "country_code": "QA",
+      "country_name": "Qatar",
       "default": true
     }
-  }
+  },
+  "discount_applications": [],
+  "fulfillments": [],
+  "line_items": [
+    {
+      "id": 14599558693185,
+      "admin_graphql_api_id": "gid://shopify/LineItem/14599558693185",
+      "fulfillable_quantity": 20,
+      "fulfillment_service": "manual",
+      "fulfillment_status": null,
+      "gift_card": false,
+      "grams": 0,
+      "name": "Artisan Aesthetics 47",
+      "price": "8.00",
+      "price_set": {
+        "shop_money": {
+          "amount": "8.00",
+          "currency_code": "QAR"
+        },
+        "presentment_money": {
+          "amount": "8.00",
+          "currency_code": "QAR"
+        }
+      },
+      "product_exists": true,
+      "product_id": 8549193417025,
+      "properties": [
+        {
+          "name": "Envelope Text",
+          "value": "C"
+        },
+        {
+          "name": "Card Text",
+          "value": "B"
+        },
+        {
+          "name": "Requests and Comments",
+          "value": "A"
+        }
+      ],
+      "quantity": 20,
+      "requires_shipping": true,
+      "sku": null,
+      "taxable": true,
+      "title": "Artisan Aesthetics 47",
+      "total_discount": "0.00",
+      "total_discount_set": {
+        "shop_money": {
+          "amount": "0.00",
+          "currency_code": "QAR"
+        },
+        "presentment_money": {
+          "amount": "0.00",
+          "currency_code": "QAR"
+        }
+      },
+      "variant_id": 46205971005761,
+      "variant_inventory_management": "shopify",
+      "variant_title": null,
+      "vendor": "Pixels â€¢ Ø¨ÙŠÙƒØ³Ù„Ø²",
+      "tax_lines": [],
+      "duties": [],
+      "discount_allocations": []
+    }
+  ],
+  "payment_terms": null,
+  "refunds": [],
+  "shipping_address": {
+    "first_name": "Meme",
+    "address1": "Zone 53 Almearad, street 1215, home 23",
+    "phone": "60097002",
+    "city": "Alwajba",
+    "zip": null,
+    "province": null,
+    "country": "Qatar",
+    "last_name": "Alshamari",
+    "address2": null,
+    "company": null,
+    "latitude": 25.233711,
+    "longitude": 51.4216387,
+    "name": "Meme Alshamari",
+    "country_code": "QA",
+    "province_code": null
+  },
+  "shipping_lines": [
+    {
+      "id": 4639048925505,
+      "carrier_identifier": "650f1a14fa979ec5c74d063e968411d4",
+      "code": "Standard Delivery (24h)",
+      "delivery_category": null,
+      "discounted_price": "30.00",
+      "discounted_price_set": {
+        "shop_money": {
+          "amount": "30.00",
+          "currency_code": "QAR"
+        },
+        "presentment_money": {
+          "amount": "30.00",
+          "currency_code": "QAR"
+        }
+      },
+      "phone": null,
+      "price": "30.00",
+      "price_set": {
+        "shop_money": {
+          "amount": "30.00",
+          "currency_code": "QAR"
+        },
+        "presentment_money": {
+          "amount": "30.00",
+          "currency_code": "QAR"
+        }
+      },
+      "requested_fulfillment_service_id": null,
+      "source": "shopify",
+      "title": "Standard Delivery (24h)",
+      "tax_lines": [],
+      "discount_allocations": []
+    }
+  ]
 }


### PR DESCRIPTION
Provides new middleware that checks incoming request headers -- intended for webhook calls -- that the request does indeed come from shopify.

The middleware runs on all endpoints on the `shopify` scope and follows the procedure defined in https://shopify.dev/docs/apps/build/webhooks.

The HMAC check can be disabled, by setting the `shopify_hmac_checks` to `false`. This is intended for testing only and is not recommended for production.