### PR TITLE
feat: order claim

### DIFF
--- a/tari_payment_engine/src/db_types.rs
+++ b/tari_payment_engine/src/db_types.rs
@@ -251,6 +251,16 @@ impl PartialEq for Order {
 
 impl Eq for Order {}
 
+impl Order {
+    pub fn expires_at(&self) -> Option<DateTime<Utc>> {
+        match self.status {
+            OrderStatusType::New => Some(self.updated_at + chrono::Duration::hours(6)),
+            // todo! add claimed status to extend expiry time
+            _ => None,
+        }
+    }
+}
+
 //--------------------------------------        NewOrder       ---------------------------------------------------------
 #[derive(Debug, Clone)]
 pub struct NewOrder {

--- a/tari_payment_engine/src/events/event_types.rs
+++ b/tari_payment_engine/src/events/event_types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tari_common_types::tari_address::TariAddress;
 use tpg_common::MicroTari;
 
 use crate::{
@@ -54,6 +55,18 @@ pub struct OrderModifiedEvent {
 impl OrderModifiedEvent {
     pub fn new(field_changed: String, orders: OrderChanged) -> Self {
         Self { field_changed, orders }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrderClaimedEvent {
+    pub order: Order,
+    pub claimant: TariAddress,
+}
+
+impl OrderClaimedEvent {
+    pub fn new(order: Order, claimant: TariAddress) -> Self {
+        Self { order, claimant }
     }
 }
 

--- a/tari_payment_engine/src/events/hooks.rs
+++ b/tari_payment_engine/src/events/hooks.rs
@@ -5,6 +5,7 @@ use crate::events::{
     EventProducer,
     Handler,
     OrderAnnulledEvent,
+    OrderClaimedEvent,
     OrderEvent,
     OrderModifiedEvent,
     PaymentEvent,
@@ -21,6 +22,7 @@ pub struct EventProducers {
     pub new_order_producer: Vec<EventProducer<OrderEvent>>,
     pub order_annulled_producer: Vec<EventProducer<OrderAnnulledEvent>>,
     pub order_modified_producer: Vec<EventProducer<OrderModifiedEvent>>,
+    pub order_claimed_producer: Vec<EventProducer<OrderClaimedEvent>>,
     pub payment_received_producer: Vec<EventProducer<PaymentEvent>>,
     pub payment_confirmed_producer: Vec<EventProducer<PaymentEvent>>,
 }
@@ -32,6 +34,7 @@ pub struct EventHandlers {
     pub on_new_order: Option<EventHandler<OrderEvent>>,
     pub on_order_annulled: Option<EventHandler<OrderAnnulledEvent>>,
     pub on_order_modified: Option<EventHandler<OrderModifiedEvent>>,
+    pub on_order_claimed: Option<EventHandler<OrderClaimedEvent>>,
     pub on_payment_received: Option<EventHandler<PaymentEvent>>,
     pub on_payment_confirmed: Option<EventHandler<PaymentEvent>>,
 }
@@ -42,6 +45,7 @@ impl EventHandlers {
         let on_new_order = hooks.on_new_order.map(|f| EventHandler::new(buffer_size, f));
         let on_order_annulled = hooks.on_order_annulled.map(|f| EventHandler::new(buffer_size, f));
         let on_order_modified = hooks.on_order_modified.map(|f| EventHandler::new(buffer_size, f));
+        let on_order_claimed = hooks.on_order_claimed.map(|f| EventHandler::new(buffer_size, f));
         let on_payment_received = hooks.on_payment_received.map(|f| EventHandler::new(buffer_size, f));
         let on_payment_confirmed = hooks.on_payment_confirmed.map(|f| EventHandler::new(buffer_size, f));
         Self {
@@ -49,6 +53,7 @@ impl EventHandlers {
             on_new_order,
             on_order_annulled,
             on_order_modified,
+            on_order_claimed,
             on_payment_received,
             on_payment_confirmed,
         }
@@ -124,6 +129,7 @@ pub struct EventHooks {
     pub on_new_order: Option<Handler<OrderEvent>>,
     pub on_order_annulled: Option<Handler<OrderAnnulledEvent>>,
     pub on_order_modified: Option<Handler<OrderModifiedEvent>>,
+    pub on_order_claimed: Option<Handler<OrderClaimedEvent>>,
     pub on_payment_received: Option<Handler<PaymentEvent>>,
     pub on_payment_confirmed: Option<Handler<PaymentEvent>>,
 }
@@ -144,6 +150,12 @@ impl EventHooks {
     pub fn on_order_modified<F>(&mut self, f: F) -> &mut Self
     where F: (Fn(OrderModifiedEvent) -> Pin<Box<dyn Future<Output = ()> + Send>>) + Send + Sync + 'static {
         self.on_order_modified = Some(Arc::new(f));
+        self
+    }
+
+    pub fn on_order_claimed<F>(&mut self, f: F) -> &mut Self
+    where F: (Fn(OrderClaimedEvent) -> Pin<Box<dyn Future<Output = ()> + Send>>) + Send + Sync + 'static {
+        self.on_order_claimed = Some(Arc::new(f));
         self
     }
 

--- a/tari_payment_engine/src/helpers/mod.rs
+++ b/tari_payment_engine/src/helpers/mod.rs
@@ -6,6 +6,6 @@ mod wallet_signature;
 mod gumbo;
 
 pub use address_extractor::extract_order_number_from_memo;
-pub use gumbo::create_dummy_address_for_cust_id;
+pub use gumbo::{create_dummy_address_for_cust_id, get_payment_wallet_address};
 pub use memo_signature::{extract_and_verify_memo_signature, MemoSignature, MemoSignatureError};
 pub use wallet_signature::{WalletSignature, WalletSignatureError};

--- a/tari_payment_engine/src/traits/payment_gateway_database.rs
+++ b/tari_payment_engine/src/traits/payment_gateway_database.rs
@@ -43,9 +43,8 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
     async fn fetch_or_create_account_for_payment(&self, payment: &Payment) -> Result<i64, PaymentGatewayError>;
 
     /// Takes a new order, and in a single atomic transaction,
-    /// * calls `save_new_order` to store the order in the database. If the order already exists, nothing further is
-    ///   done.
-    /// * creates a new account for the customer if one does not already exist
+    /// * Stores the order in the database. If the order already exists, nothing further is done.
+    /// * Creates a new account for the customer if one does not already exist
     /// * Updates the total orders value for the account
     ///
     /// Returns the account id for the customer.
@@ -236,6 +235,8 @@ pub enum PaymentGatewayError {
     OrderNotFound(OrderId),
     #[error("{0} are not supported yet")]
     UnsupportedAction(String),
+    #[error("Cannot claim order because the signature is invalid.")]
+    InvalidSignature,
 }
 
 impl From<sqlx::Error> for PaymentGatewayError {

--- a/tari_payment_server/src/server.rs
+++ b/tari_payment_server/src/server.rs
@@ -30,10 +30,10 @@ use crate::{
     routes::{
         health,
         AccountRoute,
-        AttachOrderToAddressRoute,
         AuthRoute,
         CancelOrderRoute,
         CheckTokenRoute,
+        ClaimOrderRoute,
         CreditorsRoute,
         FulfilOrderRoute,
         HistoryForAddressRoute,
@@ -59,6 +59,7 @@ use crate::{
         UpdateRolesRoute,
     },
 };
+
 /// Defines the log format for the access log middleware.
 const LOG_FORMAT: &str = concat!(
     "%t ",                                   // Time when the request was started to process
@@ -127,6 +128,7 @@ pub fn create_server_instance(
             .service(UnfulfilledOrdersRoute::<SqliteDatabase>::new())
             .service(OrdersRoute::<SqliteDatabase>::new())
             .service(OrderByIdRoute::<SqliteDatabase>::new())
+            .service(ClaimOrderRoute::<SqliteDatabase>::new())
             .service(MyPaymentsRoute::<SqliteDatabase>::new())
             .service(PaymentsRoute::<SqliteDatabase>::new())
             .service(OrdersSearchRoute::<SqliteDatabase>::new())
@@ -138,7 +140,6 @@ pub fn create_server_instance(
             .service(UpdatePriceRoute::<SqliteDatabase>::new())
             .service(ReassignOrderRoute::<SqliteDatabase>::new())
             .service(ResetOrderRoute::<SqliteDatabase>::new())
-            .service(AttachOrderToAddressRoute::<SqliteDatabase>::new())
             .service(CheckTokenRoute::new());
         let use_x_forwarded_for = config.use_x_forwarded_for;
         let use_forwarded = config.use_forwarded;

--- a/taritools/src/shopify/command_handler.rs
+++ b/taritools/src/shopify/command_handler.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use shopify_tools::{ExchangeRate, ShopifyApi, ShopifyConfig};
 
 use crate::shopify::{command_def::RatesCommand, OrdersCommand, ShopifyCommand};


### PR DESCRIPTION
Users can claim an order (that is, associate a new order with their wallet address) using the `/order/claim` endpoint.
This is a `POST` endpoint that requires a JSON body containing a [`MemoSignature`] object.