### PR TITLE
feat: multi-order payment

### DIFF
--- a/e2e/tests/features/claim_order.feature
+++ b/e2e/tests/features/claim_order.feature
@@ -38,6 +38,60 @@ Feature: Order claiming
     }
     """
 
+  # ----------------------------- Memo Signature -----------------------------
+  # Wallet address: 480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88
+  # Public key    : 480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a
+  # emoji id      : 🎢🌋🐲🎠🍄🍬🌂🍊👕🎳🍼💕👖👒🚒🍆🍈🔭🚑🐭🌝🎓👖🚂🎨🌴💀🍄🌟🌰🔪🐜🐳
+  # Secret        : ac8bac66b8efc8f2055ba8dcd95ad5f7f9e791d876a50642d563426fc86de109
+  # Network       : mainnet
+  # auth: {"address":"480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88","order_id":"anon101","signature":"2ee4933f2a845e424a784d0c35d84bfb2836191aa5ffc4adc20de3b733da8478c0a0afcf941ed8a26d195eb1f748d2101ed6434af49823994334778385fc0b04"}
+  # ------------------------------------------------------------------------
   Scenario: Previously unlinked accounts can claim an order with the correct signature, and the order can be paid.
+    Given a payment of 100 XTR from address 480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88 in tx tx4804forAnon100
+    When Customer #999 ["who@example.com"] places order "anon100" for 60 XTR, with memo
+    When User POSTs to "/order/claim" with body
+    """
+    {
+       "address":"480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88",
+       "order_id":"anon100",
+       "signature":"1295995d5698365ecc82ee7acf4acd11dfe678a9b860fd2054d1d3b5b9c14951daa3a09dd00fa9869fedf5e321b877a22ad3cc7291e93d3d320e2d4ac8134d05"
+    }
+    """
+    Then I receive a 200 Ok response
+    Then the OrderClaimed trigger fires with
+    """
+    {
+      "order": { "order_id": "anon100", "total_price": 60000000, "status": "New" },
+      "claimant": "480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88"
+    }
+    """
+    Then the OrderPaid trigger fires with
+    """
+    {
+      "order": { "order_id": "anon100", "total_price": 60000000, "status": "Paid" }
+    }
+    """
+
 
   Scenario: New addresses can claim an order with the correct signature.
+    When Customer #999 ["who@example.com"] places order "anon101" for 28 XTR, with memo
+    When User POSTs to "/order/claim" with body
+    """
+    {
+       "address":"480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88",
+       "order_id":"anon101",
+       "signature":"2ee4933f2a845e424a784d0c35d84bfb2836191aa5ffc4adc20de3b733da8478c0a0afcf941ed8a26d195eb1f748d2101ed6434af49823994334778385fc0b04"
+    }
+    """
+    Then I receive a 200 Ok response
+    And I receive a partial JSON response:
+    """
+    { "order_id": "anon101", "total_price": 28000000 }
+    """
+    Then the OrderClaimed trigger fires with
+    """
+    {
+      "order": { "order_id": "anon101", "total_price": 28000000, "status": "New" },
+      "claimant": "480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88"
+    }
+    """

--- a/tari_payment_engine/src/db_types.rs
+++ b/tari_payment_engine/src/db_types.rs
@@ -120,7 +120,7 @@ impl Hash for SerializedTariAddress {
 }
 
 //--------------------------------------     UserAccount       ---------------------------------------------------------
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, Default)]
 pub struct UserAccount {
     pub id: i64,
     pub created_at: DateTime<Utc>,

--- a/tari_payment_engine/src/events/channel.rs
+++ b/tari_payment_engine/src/events/channel.rs
@@ -67,7 +67,7 @@ impl<E: Send + Sync + 'static> EventHandler<E> {
                 );
             },
         }
-        info!("📬️ Event handler has shut down");
+        debug!("📬️ Event handler has shut down");
     }
 }
 

--- a/tari_payment_engine/src/traits/data_objects.rs
+++ b/tari_payment_engine/src/traits/data_objects.rs
@@ -1,7 +1,8 @@
-use std::net::IpAddr;
+use std::{fmt::Display, net::IpAddr};
 
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use tpg_common::MicroTari;
 
 use crate::{
     db_types::{Order, SerializedTariAddress},
@@ -48,5 +49,44 @@ impl OrderMovedResult {
         } else {
             None
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultiAccountPayment {
+    pub address: SerializedTariAddress,
+    pub orders_paid: Vec<Order>,
+    /// An array of account ids used to pay for the orders, as well as the amount paid from each account
+    pub wallet_accounts_used: Vec<(i64, MicroTari)>,
+}
+
+impl MultiAccountPayment {
+    pub fn new(address: SerializedTariAddress, orders_paid: Vec<Order>, accounts: &[(i64, MicroTari)]) -> Self {
+        Self { address, orders_paid, wallet_accounts_used: accounts.to_vec() }
+    }
+
+    pub fn order_count(&self) -> usize {
+        self.orders_paid.len()
+    }
+
+    pub fn account_count(&self) -> usize {
+        self.wallet_accounts_used.len()
+    }
+
+    pub fn total_paid(&self) -> MicroTari {
+        self.wallet_accounts_used.iter().map(|(_, amount)| *amount).sum()
+    }
+}
+
+impl Display for MultiAccountPayment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MultiAccountPayment from address {}:", self.address.as_address())?;
+        writeln!(
+            f,
+            "{} orders paid from {} accounts for a total of {}",
+            self.order_count(),
+            self.account_count(),
+            self.total_paid()
+        )
     }
 }

--- a/tari_payment_engine/src/traits/mod.rs
+++ b/tari_payment_engine/src/traits/mod.rs
@@ -32,7 +32,7 @@ mod data_objects;
 
 pub use account_management::{AccountApiError, AccountManagement};
 pub use auth_management::{AuthApiError, AuthManagement};
-pub use data_objects::{NewWalletInfo, OrderMovedResult, UpdateWalletInfo, WalletInfo};
+pub use data_objects::{MultiAccountPayment, NewWalletInfo, OrderMovedResult, UpdateWalletInfo, WalletInfo};
 pub use exchange_rates::{ExchangeRateError, ExchangeRates};
 pub use payment_gateway_database::{PaymentGatewayDatabase, PaymentGatewayError};
 pub use wallet_management::{WalletAuth, WalletAuthApiError, WalletManagement, WalletManagementError};


### PR DESCRIPTION
Allows payment for orders from _any_ account associated with a given address, once an order has been claimed by said address.