### PR TITLE
feat: order expiry

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,6 +19,11 @@ TPG_USE_FORWARDED=0
 TPG_JWT_SIGNING_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TPG_JWT_VERIFICATION_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# Expiry time for new, unclaimed orders, in hours
+TPG_UNCLAIMED_ORDER_TIMEOUT=2
+# Expiry time for unpaid orders, in hours
+TPG_UNPAID_ORDER_TIMEOUT=48
+
 # Development only
 #DATABASE_URL=postgres://postgres:postgres@localhost:5432/shopify_payment_gateway
 DATABASE_URL=sqlite://data/tari_store.db

--- a/e2e/tests/cucumber/world.rs
+++ b/e2e/tests/cucumber/world.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use actix_web::dev::ServerHandle;
+use chrono::Duration;
 use cucumber::World;
 use log::*;
 use reqwest::{Client, Method, RequestBuilder, StatusCode};
@@ -55,6 +56,8 @@ impl Default for TPGWorld {
             shopify_whitelist: None,
             use_x_forwarded_for: false,
             use_forwarded: false,
+            unclaimed_order_timeout: Duration::seconds(1),
+            unpaid_order_timeout: Duration::seconds(2),
         };
         Self {
             config,

--- a/e2e/tests/features/expiry.feature
+++ b/e2e/tests/features/expiry.feature
@@ -1,0 +1,36 @@
+@expiry
+Feature: Expire old orders
+  Background:
+    # For testing, the expiry limits are 1s for unclaimed and 2s for unpaid
+
+
+  Scenario: Expire unclaimed orders
+    Given a blank slate
+    When Customer #1 ["Alex"] places order "order1" for 1 XTR, with memo
+    Then order "order1" is in state Unclaimed
+    And account for 1 has current orders worth 1 XTR
+    Then pause for 2000 ms
+    When I expire old orders
+    Then order "order1" is in state Expired
+    And account for 1 has current orders worth 0 XTR
+
+
+  Scenario: Expire a mix of orders
+    Given a database with some accounts
+    Then account for alice has current orders worth 165 XTR
+    When Customer #1 ["Alex"] places order "order1" for 1 XTR, with memo
+    Then order "order1" is in state Unclaimed
+    Then order "1" is in state New
+    Then pause for 1000 ms
+    When Customer #2 ["Barb"] places order "order2" for 1 XTR, with memo
+    Then pause for 800 ms
+    When I expire old orders
+    Then order "order1" is in state Expired
+    Then order "order2" is in state Unclaimed
+    Then order "1" is in state New
+    Then pause for 1100 ms
+    When I expire old orders
+    Then order "order2" is in state Expired
+    Then order "1" is in state Expired
+    # All Alice's orders have expired
+    And account for alice has current orders worth 0 XTR

--- a/e2e/tests/features/expiry.feature
+++ b/e2e/tests/features/expiry.feature
@@ -21,9 +21,9 @@ Feature: Expire old orders
     When Customer #1 ["Alex"] places order "order1" for 1 XTR, with memo
     Then order "order1" is in state Unclaimed
     Then order "1" is in state New
-    Then pause for 1000 ms
+    Then pause for 500 ms
     When Customer #2 ["Barb"] places order "order2" for 1 XTR, with memo
-    Then pause for 800 ms
+    Then pause for 550 ms
     When I expire old orders
     Then order "order1" is in state Expired
     Then order "order2" is in state Unclaimed

--- a/tari_payment_engine/src/db_types.rs
+++ b/tari_payment_engine/src/db_types.rs
@@ -141,8 +141,10 @@ pub enum OrderStatusType {
     Cancelled,
     /// The order has expired.
     Expired,
-    /// The order is newly created, and no payments have been received.
+    /// The order is newly created, unpaid, and matched to a wallet address
     New,
+    /// The order is newly created, and is not associated with any wallet address
+    Unclaimed,
 }
 
 impl Display for OrderStatusType {
@@ -152,6 +154,7 @@ impl Display for OrderStatusType {
             OrderStatusType::Cancelled => write!(f, "Cancelled"),
             OrderStatusType::Expired => write!(f, "Expired"),
             OrderStatusType::New => write!(f, "New"),
+            OrderStatusType::Unclaimed => write!(f, "Unclaimed"),
         }
     }
 }
@@ -159,8 +162,8 @@ impl Display for OrderStatusType {
 impl From<String> for OrderStatusType {
     fn from(value: String) -> Self {
         value.parse().unwrap_or_else(|_| {
-            error!("Invalid order status: {value}. But this conversion cannot fail. Defaulting to New");
-            OrderStatusType::New
+            error!("Invalid order status: {value}. But this conversion cannot fail. Defaulting to Unclaimed");
+            OrderStatusType::Unclaimed
         })
     }
 }
@@ -177,6 +180,7 @@ impl FromStr for OrderStatusType {
             "Cancelled" => Ok(Self::Cancelled),
             "Expired" => Ok(Self::Expired),
             "New" => Ok(Self::New),
+            "Unclaimed" => Ok(Self::Unclaimed),
             s => Err(ConversionError(format!("Invalid order status: {s}"))),
         }
     }

--- a/tari_payment_engine/src/sqlite/db/user_accounts.rs
+++ b/tari_payment_engine/src/sqlite/db/user_accounts.rs
@@ -226,20 +226,20 @@ async fn acc_id_for_cust_id(cid: &str, conn: &mut SqliteConnection) -> Result<Op
 /// Creates a new user account in the database and links it to the given customer id and/or public key.
 async fn create_account_with_links(
     cid: Option<String>,
-    pk: Option<TariAddress>,
+    address: Option<TariAddress>,
     tx: &mut SqliteConnection,
 ) -> Result<i64, AccountApiError> {
     let row = sqlx::query!("INSERT INTO user_accounts DEFAULT VALUES RETURNING id").fetch_one(&mut *tx).await?;
     let account_id = row.id;
     debug!("📝️ Created new user account with id #{account_id}");
-    link_accounts(account_id, cid, pk, tx).await
+    link_accounts(account_id, cid, address, tx).await
 }
 
 /// Links a customer id and/or address in the database with the given internal account number.
 pub async fn link_accounts(
     acc_id: i64,
     cid: Option<String>,
-    pk: Option<TariAddress>,
+    address: Option<TariAddress>,
     tx: &mut SqliteConnection,
 ) -> Result<i64, AccountApiError> {
     if let Some(cid) = cid {
@@ -255,8 +255,8 @@ pub async fn link_accounts(
         }
         debug!("🧑️ Linked user account #{acc_id} to customer_id {cid}");
     };
-    if let Some(pk) = pk {
-        let addr = pk.to_hex();
+    if let Some(addr) = address {
+        let addr = addr.to_hex();
         let result =
             sqlx::query!("INSERT INTO user_account_address (user_account_id, address) VALUES ($1, $2)", acc_id, addr,)
                 .execute(tx)
@@ -264,7 +264,7 @@ pub async fn link_accounts(
         if let Err(e) = result {
             error!("Could not link tari address and user account. {e}");
         }
-        debug!("🧑️ Linked user account #{acc_id} to Tari address {pk}");
+        debug!("🧑️ Linked user account #{acc_id} to Tari address {addr}");
     };
     Ok(acc_id)
 }

--- a/tari_payment_engine/src/sqlite/migrations/0001_create_orders.up.sql
+++ b/tari_payment_engine/src/sqlite/migrations/0001_create_orders.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE orders (
     currency TEXT NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at   DATETIME NOT NULL  DEFAULT CURRENT_TIMESTAMP,
-    status TEXT NOT NULL CHECK(status IN ('Paid', 'Cancelled', 'Expired', 'New')) DEFAULT 'New'
+    status TEXT NOT NULL CHECK(status IN ('Paid', 'Cancelled', 'Expired', 'New', 'Unclaimed')) DEFAULT 'Unclaimed'
 );
 
 CREATE INDEX orders_order_id_idx ON orders (order_id);

--- a/tari_payment_engine/src/sqlite/migrations/0004_create_accounts.up.sql
+++ b/tari_payment_engine/src/sqlite/migrations/0004_create_accounts.up.sql
@@ -61,7 +61,7 @@ END;
 
 -- Adjust total orders received balance down if an order is expired or cancelled.
 CREATE TRIGGER order_cancelled_trigger AFTER UPDATE OF status ON orders
-WHEN OLD.status = 'New' AND NEW.status in ('Cancelled', 'Expired')
+WHEN (OLD.status = 'New' OR OLD.status = 'Unclaimed') AND NEW.status in ('Cancelled', 'Expired')
 BEGIN
     UPDATE user_accounts
     SET

--- a/tari_payment_engine/src/tpe_api/order_flow_api.rs
+++ b/tari_payment_engine/src/tpe_api/order_flow_api.rs
@@ -79,7 +79,7 @@ where B: PaymentGatewayDatabase
             .await?
             .ok_or_else(|| PaymentGatewayError::OrderNotFound(order_id.clone()))?;
         let address = signature.address.as_address();
-        let account = self.db.attach_order_to_address(&order_id, address).await?;
+        let (account, order) = self.db.attach_order_to_address(&order_id, address).await?;
         debug!("🖇️📦️ Order [{order_id}] is attached to account {}", account.id);
         self.call_order_claimed_hook(&order, address).await;
         // If payment is successful, order OrderPaid trigger will fire implicitly.

--- a/tari_payment_engine/src/tpe_api/order_flow_api.rs
+++ b/tari_payment_engine/src/tpe_api/order_flow_api.rs
@@ -79,7 +79,7 @@ where B: PaymentGatewayDatabase
             .await?
             .ok_or_else(|| PaymentGatewayError::OrderNotFound(order_id.clone()))?;
         let address = signature.address.as_address();
-        let (account, order) = self.db.attach_order_to_address(&order_id, address).await?;
+        let (account, order) = self.db.attach_order_to_address(&order.order_id, address).await?;
         debug!("🖇️📦️ Order [{order_id}] is attached to account {}", account.id);
         self.call_order_claimed_hook(&order, address).await;
         // If payment is successful, order OrderPaid trigger will fire implicitly.

--- a/tari_payment_engine/src/traits/data_objects.rs
+++ b/tari_payment_engine/src/traits/data_objects.rs
@@ -90,3 +90,27 @@ impl Display for MultiAccountPayment {
         )
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExpiryResult {
+    pub unclaimed: Vec<Order>,
+    pub unpaid: Vec<Order>,
+}
+
+impl ExpiryResult {
+    pub fn new(unclaimed: Vec<Order>, unpaid: Vec<Order>) -> Self {
+        Self { unclaimed, unpaid }
+    }
+
+    pub fn unclaimed_count(&self) -> usize {
+        self.unclaimed.len()
+    }
+
+    pub fn unpaid_count(&self) -> usize {
+        self.unpaid.len()
+    }
+
+    pub fn total_count(&self) -> usize {
+        self.unclaimed_count() + self.unpaid_count()
+    }
+}

--- a/tari_payment_engine/src/traits/mod.rs
+++ b/tari_payment_engine/src/traits/mod.rs
@@ -32,7 +32,14 @@ mod data_objects;
 
 pub use account_management::{AccountApiError, AccountManagement};
 pub use auth_management::{AuthApiError, AuthManagement};
-pub use data_objects::{MultiAccountPayment, NewWalletInfo, OrderMovedResult, UpdateWalletInfo, WalletInfo};
+pub use data_objects::{
+    ExpiryResult,
+    MultiAccountPayment,
+    NewWalletInfo,
+    OrderMovedResult,
+    UpdateWalletInfo,
+    WalletInfo,
+};
 pub use exchange_rates::{ExchangeRateError, ExchangeRates};
 pub use payment_gateway_database::{PaymentGatewayDatabase, PaymentGatewayError};
 pub use wallet_management::{WalletAuth, WalletAuthApiError, WalletManagement, WalletManagementError};

--- a/tari_payment_engine/src/traits/payment_gateway_database.rs
+++ b/tari_payment_engine/src/traits/payment_gateway_database.rs
@@ -220,7 +220,7 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
         address: &TariAddress,
     ) -> Result<(UserAccount, Order), PaymentGatewayError>;
 
-    /// Marks unapid and unclimaed orders as expired.
+    /// Marks unapid and unclaimed orders as expired.
     ///
     /// Any orders that have not been _updated_ (based on the `updated_at` field) for longer than the given duration
     /// will be marked as `Expired`.

--- a/tari_payment_engine/src/traits/payment_gateway_database.rs
+++ b/tari_payment_engine/src/traits/payment_gateway_database.rs
@@ -215,7 +215,7 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
         &self,
         order_id: &OrderId,
         address: &TariAddress,
-    ) -> Result<UserAccount, PaymentGatewayError>;
+    ) -> Result<(UserAccount, Order), PaymentGatewayError>;
 
     /// Closes the database connection.
     async fn close(&mut self) -> Result<(), PaymentGatewayError> {

--- a/tari_payment_server/src/expiry_worker.rs
+++ b/tari_payment_server/src/expiry_worker.rs
@@ -1,0 +1,44 @@
+use chrono::Duration;
+use log::*;
+use tari_payment_engine::{db_types::Order, events::EventProducers, OrderFlowApi, SqliteDatabase};
+use tokio::task::JoinHandle;
+
+/// Starts the expiry worker. Do not await the returned JoinHandle, as it will run indefinitely.
+pub fn start_expiry_worker(
+    db: SqliteDatabase,
+    producers: EventProducers,
+    unclaimed_expiry: Duration,
+    unpaid_expiry: Duration,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut timer = tokio::time::interval(std::time::Duration::from_secs(60));
+        let api = OrderFlowApi::new(db, producers);
+        info!("🕰️ Unclaimed order expiry worker started");
+        loop {
+            timer.tick().await;
+            info!("🕰️ Running unclaimed order expiry job");
+            match api.expire_old_orders(unclaimed_expiry, unpaid_expiry).await {
+                Ok(result) => {
+                    info!("🕰️ {} orders expired", result.total_count());
+                    debug!(
+                        "🕰️ {} Expired unclaimed orders: {}",
+                        result.unclaimed_count(),
+                        order_list(&result.unclaimed)
+                    );
+                    debug!("🕰️ {} Expired unpaid orders: {}", result.unpaid_count(), order_list(&result.unpaid));
+                },
+                Err(e) => {
+                    error!("🕰️ Error running unclaimed order expiry job: {e}");
+                },
+            }
+        }
+    })
+}
+
+fn order_list(orders: &[Order]) -> String {
+    orders
+        .iter()
+        .map(|o| format!("[{}] order_id: {} cust_id: {}", o.id, o.order_id, o.customer_id))
+        .collect::<Vec<String>>()
+        .join(", ")
+}

--- a/tari_payment_server/src/lib.rs
+++ b/tari_payment_server/src/lib.rs
@@ -53,6 +53,8 @@ pub mod config;
 pub mod data_objects;
 pub mod errors;
 
+pub mod expiry_worker;
+
 pub mod helpers;
 
 pub mod middleware;

--- a/tari_payment_server/src/routes.rs
+++ b/tari_payment_server/src/routes.rs
@@ -369,7 +369,7 @@ pub async fn unfulfilled_orders<B: AccountManagement>(
 ) -> Result<HttpResponse, ServerError> {
     let address = path.into_inner().to_address();
     debug!("💻️ GET unfulfilled_orders for {address}");
-    let query = OrderQueryFilter::default().with_status(OrderStatusType::New);
+    let query = OrderQueryFilter::default().with_status(OrderStatusType::New).with_status(OrderStatusType::Unclaimed);
     let orders = api.search_orders(query, Some(address.clone())).await.map_err(|e| {
         debug!("💻️ Could not fetch unfulfilled orders. {e}");
         ServerError::BackendError(e.to_string())


### PR DESCRIPTION
* Adds "Unclaimed" order status to mark orders that do not have a Tari
address associated with them.
* These orders will expire within 2 hours unless an address is associated
with them.
* "New" orders that haven't received a payment will have 48 hours before
being expired.
* Adds an async worker that calls the `expire_old_orders` methods every
minute.
* Any expired orders trigger the `OrderAnulled` event.
* Adds environment variables that allow for the configuration of
new order expiry limits.
  * `TPG_UNCLAIMED_ORDER_TIMEOUT` is the expiry time for new, unclaimed orders, in hours
  * `TPG_UNPAID_ORDER_TIMEOUT ` is the Expiry time for unpaid orders, in hours
* Adds a time-based expiry method to expire new and unclaimed orders after
a given period.
