### PR TITLE
tests: don't wait for graceful finish

### DIFF
--- a/e2e/tests/cucumber/steps.rs
+++ b/e2e/tests/cucumber/steps.rs
@@ -372,8 +372,8 @@ async fn instapay(world: &mut TPGWorld, amount: i64, sender: TariAddress, txid: 
 #[when(expr = "I expire old orders")]
 async fn expire_old_orders(world: &mut TPGWorld) {
     let db = world.db.as_ref().expect("No database connection");
-    let unclaimed_limit = Duration::seconds(1);
-    let unpaid_limit = Duration::seconds(2);
+    let unclaimed_limit = Duration::seconds(2);
+    let unpaid_limit = Duration::seconds(4);
     let orders = db.expire_old_orders(unclaimed_limit, unpaid_limit).await.expect("Failed to expire orders");
     info!("Expired orders: {}", serde_json::to_string(&orders).expect("Failed to serialize orders"));
 }

--- a/e2e/tests/cucumber/world.rs
+++ b/e2e/tests/cucumber/world.rs
@@ -56,8 +56,8 @@ impl Default for TPGWorld {
             shopify_whitelist: None,
             use_x_forwarded_for: false,
             use_forwarded: false,
-            unclaimed_order_timeout: Duration::seconds(1),
-            unpaid_order_timeout: Duration::seconds(2),
+            unclaimed_order_timeout: Duration::seconds(2),
+            unpaid_order_timeout: Duration::seconds(4),
         };
         Self {
             config,

--- a/e2e/tests/e2e_tests.rs
+++ b/e2e/tests/e2e_tests.rs
@@ -30,7 +30,7 @@ fn post_test_hook<'a>(
         if let Some(w) = world {
             if let Some(h) = w.server_handle.take() {
                 info!("🚀️ Stopping server");
-                h.stop(true).await;
+                h.stop(false).await;
                 info!("🚀️ Server stopped");
             }
         }

--- a/e2e/tests/features/expiry.feature
+++ b/e2e/tests/features/expiry.feature
@@ -1,7 +1,7 @@
 @expiry
 Feature: Expire old orders
   Background:
-    # For testing, the expiry limits are 1s for unclaimed and 2s for unpaid
+    # For testing, the expiry limits are 2s for unclaimed and 4s for unpaid
 
 
   Scenario: Expire unclaimed orders
@@ -9,7 +9,7 @@ Feature: Expire old orders
     When Customer #1 ["Alex"] places order "order1" for 1 XTR, with memo
     Then order "order1" is in state Unclaimed
     And account for 1 has current orders worth 1 XTR
-    Then pause for 2000 ms
+    Then pause for 3000 ms
     When I expire old orders
     Then order "order1" is in state Expired
     And account for 1 has current orders worth 0 XTR
@@ -21,14 +21,14 @@ Feature: Expire old orders
     When Customer #1 ["Alex"] places order "order1" for 1 XTR, with memo
     Then order "order1" is in state Unclaimed
     Then order "1" is in state New
-    Then pause for 500 ms
+    Then pause for 1600 ms
     When Customer #2 ["Barb"] places order "order2" for 1 XTR, with memo
-    Then pause for 550 ms
+    Then pause for 1000 ms
     When I expire old orders
     Then order "order1" is in state Expired
     Then order "order2" is in state Unclaimed
     Then order "1" is in state New
-    Then pause for 1100 ms
+    Then pause for 2000 ms
     When I expire old orders
     Then order "order2" is in state Expired
     Then order "1" is in state Expired


### PR DESCRIPTION
Waiting for graceful shutdown sometimes caused locks in tests. When test is done, just shut everything down.

Increase time window on tests that rely on clocks to reduce flakiness