### PR TITLE
feat: convert incoming order currency

### DIFF
--- a/e2e/tests/cucumber/steps.rs
+++ b/e2e/tests/cucumber/steps.rs
@@ -242,10 +242,10 @@ async fn place_order(
         .request(Method::POST, "/shopify/webhook/checkout_create", |req| {
             let mut order = ShopifyOrder::default();
             order.created_at = created_at;
-            order.name = order_id;
+            order.id = order_id;
             order.note = memo;
             order.currency = "XTR".to_string();
-            order.total_price = MicroTari::from_tari(amount).value().to_string();
+            order.total_price = format!("{amount}.00");
             order.user_id = Some(user);
             order.email = Some(email);
             order.customer.id = user;

--- a/e2e/tests/cucumber/world.rs
+++ b/e2e/tests/cucumber/world.rs
@@ -50,6 +50,7 @@ impl Default for TPGWorld {
             port: 20000 + rand::random::<u16>() % 10_000,
             shopify_api_key: String::default(),
             shopify_api_secret: Secret::default(),
+            shopify_hmac_secret: Secret::default(),
             shopify_hmac_checks: false,
             database_url: url.clone(),
             auth: AuthConfig::default(),

--- a/shopify_tools/Cargo.toml
+++ b/shopify_tools/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 tpg_common = { version = "0.1.0", path = "../tpg_common" }
-chrono = "0.4.38"
+chrono = { version = "0.4.31", features = ["serde"] }
 graphql-parser = "0.4.0"
 log = "0.4.21"
 rand = "0.9.0-alpha.1"
@@ -13,4 +13,5 @@ reqwest = {  version = "0.12.5", features = ["json"] }
 serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.68"
 thiserror = "1.0.61"
+
 

--- a/shopify_tools/src/shopify_order.rs
+++ b/shopify_tools/src/shopify_order.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ShopifyOrder {
-    pub id: i64,
+    pub id: String,
     pub token: String,
-    pub cart_token: String,
+    pub cart_token: Option<String>, // marked as deprecated in shopify API
     pub email: Option<String>,
     pub buyer_accepts_marketing: bool,
     pub created_at: String,
@@ -16,8 +16,8 @@ pub struct ShopifyOrder {
     pub presentment_currency: String,
     pub cancel_reason: Option<String>,
     pub cancelled_at: Option<String>,
-    pub checkout_id: i64,
-    pub checkout_token: String,
+    pub checkout_id: Option<i64>,
+    pub checkout_token: Option<String>, // marked as deprecated in shopify API
     pub closed_at: Option<String>,
     pub confirmed: bool,
     pub user_id: Option<i64>,
@@ -181,9 +181,9 @@ impl OrderBuilder {
         #[allow(clippy::cast_possible_wrap)]
         let id = (rng.next_u64() >> 1) as i64;
         ShopifyOrder {
-            id,
+            id: id.to_string(),
             token: self.token.unwrap_or_else(|| rng.next_u64().to_string()),
-            cart_token: self.cart_token.unwrap_or_else(|| format!("{:x}", rng.next_u64())),
+            cart_token: self.cart_token,
             email: Some(self.email.unwrap_or_else(|| format!("{}@example.com", rng.gen_range(0..1000)))),
             buyer_accepts_marketing: self.buyer_accepts_marketing.unwrap_or_default(),
             created_at: self.created_at.unwrap_or_else(|| Utc::now().to_rfc3339()),
@@ -199,14 +199,14 @@ impl OrderBuilder {
             presentment_currency: self.presentment_currency.unwrap_or_else(|| "XTR".to_string()),
             cancel_reason: None,
             cancelled_at: None,
-            checkout_id: 12345,
+            checkout_id: None,
             total_discounts: self.total_discounts.unwrap_or_default(),
             total_line_items_price: self.total_line_items_price.unwrap_or_default(),
             total_price: self.total_price.unwrap_or_else(|| format!("{}", rng.gen_range(1_000..250_000) * 1000)),
             total_tax: self.total_tax.unwrap_or_default(),
             subtotal_price: self.subtotal_price.unwrap_or_default(),
             customer: self.customer.unwrap_or_default(),
-            checkout_token: "checkouttoken12345".to_string(),
+            checkout_token: None,
         }
     }
 }
@@ -219,19 +219,19 @@ mod test {
     fn deserialize_new_order() {
         let order = include_str!("./test_assets/new_order.json");
         let order: ShopifyOrder = serde_json::from_str(order).unwrap();
-        assert_eq!(order.id, 5714720719169);
+        assert_eq!(order.id, "5714720719169");
         assert_eq!(order.token, "04eaa913ca3ccc9c99603a5921a1268d");
         assert_eq!(order.total_price, "190.00");
         assert_eq!(order.customer.id, 7806520164673);
 
         let order = include_str!("./test_assets/actual_order.json");
         let order: ShopifyOrder = serde_json::from_str(order).unwrap();
-        assert_eq!(order.id, 5621163655380);
+        assert_eq!(order.id, "5621163655380");
         assert_eq!(order.customer.id, 7345051926740);
 
         let order = include_str!("./test_assets/actual_order2.json");
         let order: ShopifyOrder = serde_json::from_str(order).unwrap();
-        assert_eq!(order.id, 5621189509332);
-        assert_eq!(order.customer.id, 7345180737748);
+        assert_eq!(order.id, "820982911946154508");
+        assert_eq!(order.customer.id, 115310627314723954);
     }
 }

--- a/shopify_tools/src/shopify_order.rs
+++ b/shopify_tools/src/shopify_order.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ShopifyOrder {
+    #[serde(deserialize_with = "into_string")]
     pub id: String,
     pub token: String,
     pub cart_token: Option<String>, // marked as deprecated in shopify API
@@ -30,6 +31,17 @@ pub struct ShopifyOrder {
     pub total_tax: String,
     pub subtotal_price: String,
     pub customer: Customer,
+}
+
+fn into_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where D: serde::Deserializer<'de> {
+    let deserialized_value: serde_json::Value = serde::Deserialize::deserialize(deserializer)?;
+
+    match deserialized_value {
+        serde_json::Value::String(s) => Ok(s),
+        serde_json::Value::Number(num) => Ok(num.to_string()),
+        _ => Err(serde::de::Error::custom("expected a string or number")),
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/shopify_tools/src/test_assets/actual_order2.json
+++ b/shopify_tools/src/test_assets/actual_order2.json
@@ -1,35 +1,29 @@
 {
-  "id": 5621189509332,
-  "admin_graphql_api_id": "gid://shopify/Order/5621189509332",
-  "app_id": 580111,
-  "browser_ip": "94.63.235.150",
-  "buyer_accepts_marketing": false,
-  "cancel_reason": null,
-  "cancelled_at": null,
-  "cart_token": "Z2NwLWV1cm9wZS13ZXN0MTowMUowUlJIN1dTSEoyNURFM1M1U05NSjlLUg",
-  "checkout_id": 36497036214484,
-  "checkout_token": "fb5df8f4899923136c762fb7d55bd4bf",
-  "client_details": {
-    "accept_language": "en-US",
-    "browser_height": null,
-    "browser_ip": "94.63.235.150",
-    "browser_width": null,
-    "session_hash": null,
-    "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0"
-  },
+  "id": 820982911946154508,
+  "admin_graphql_api_id": "gid:\/\/shopify\/Order\/820982911946154508",
+  "app_id": null,
+  "browser_ip": null,
+  "buyer_accepts_marketing": true,
+  "cancel_reason": "customer",
+  "cancelled_at": "2024-06-30T20:13:52+01:00",
+  "cart_token": null,
+  "checkout_id": null,
+  "checkout_token": null,
+  "client_details": null,
   "closed_at": null,
-  "confirmation_number": "RQ50HVD85",
-  "confirmed": true,
-  "created_at": "2024-06-19T18:29:13+01:00",
+  "confirmation_number": null,
+  "confirmed": false,
+  "contact_email": "jon@example.com",
+  "created_at": "2024-06-30T20:13:52+01:00",
   "currency": "USD",
-  "current_subtotal_price": "24.00",
+  "current_subtotal_price": "11.50",
   "current_subtotal_price_set": {
     "shop_money": {
-      "amount": "24.00",
+      "amount": "11.50",
       "currency_code": "USD"
     },
     "presentment_money": {
-      "amount": "24.00",
+      "amount": "11.50",
       "currency_code": "USD"
     }
   },
@@ -46,14 +40,14 @@
     }
   },
   "current_total_duties_set": null,
-  "current_total_price": "28.90",
+  "current_total_price": "11.50",
   "current_total_price_set": {
     "shop_money": {
-      "amount": "28.90",
+      "amount": "11.50",
       "currency_code": "USD"
     },
     "presentment_money": {
-      "amount": "28.90",
+      "amount": "11.50",
       "currency_code": "USD"
     }
   },
@@ -68,92 +62,97 @@
       "currency_code": "USD"
     }
   },
-  "customer_locale": "en-US",
+  "customer_locale": "en",
   "device_id": null,
   "discount_codes": [],
+  "duties_included": false,
+  "email": "jon@example.com",
   "estimated_taxes": false,
-  "financial_status": "pending",
-  "fulfillment_status": null,
-  "landing_site": "/password",
+  "financial_status": "voided",
+  "fulfillment_status": "pending",
+  "landing_site": null,
   "landing_site_ref": null,
   "location_id": null,
   "merchant_of_record_app_id": null,
-  "name": "#1003",
-  "note": "{\"address\":\"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d\",\"order_id\":\"order1001\",\"signature\":\"ae26f3139d6505bfe28452ddd00e76ba04354114959ea95e7248a13cd673d02288e3e42f416dc42cc51ecca8bf6b44a2819cfcd4f2507c6ec9af9c92621ffa0c\"}",
+  "name": "#9999",
+  "note": null,
   "note_attributes": [],
-  "number": 3,
-  "order_number": 1003,
+  "number": 234,
+  "order_number": 1234,
+  "order_status_url": "https:\/\/af2f05-9a.myshopify.com\/70504906964\/orders\/123456abcd\/authenticate?key=abcdefg",
   "original_total_additional_fees_set": null,
   "original_total_duties_set": null,
   "payment_gateway_names": [
-    "Tari Payment Server"
+    "visa",
+    "bogus"
   ],
+  "phone": null,
   "po_number": null,
   "presentment_currency": "USD",
-  "processed_at": "2024-06-19T18:29:11+01:00",
-  "reference": "89195f12161a3ce821463e209e6d7455",
-  "referring_site": "",
-  "source_identifier": "89195f12161a3ce821463e209e6d7455",
+  "processed_at": "2024-06-30T20:13:52+01:00",
+  "reference": null,
+  "referring_site": null,
+  "source_identifier": null,
   "source_name": "web",
   "source_url": null,
-  "subtotal_price": "24.00",
+  "subtotal_price": "1.50",
   "subtotal_price_set": {
     "shop_money": {
-      "amount": "24.00",
+      "amount": "1.50",
       "currency_code": "USD"
     },
     "presentment_money": {
-      "amount": "24.00",
+      "amount": "1.50",
       "currency_code": "USD"
     }
   },
-  "tags": "",
+  "tags": "tag1, tag2",
   "tax_exempt": false,
   "tax_lines": [],
   "taxes_included": false,
-  "test": false,
-  "token": "5d3c5d2ffe01ea89bb1690bdfc537cb7",
-  "total_discounts": "0.00",
+  "test": true,
+  "token": "123456abcd",
+  "total_discounts": "20.00",
   "total_discounts_set": {
     "shop_money": {
-      "amount": "0.00",
+      "amount": "20.00",
       "currency_code": "USD"
     },
     "presentment_money": {
-      "amount": "0.00",
+      "amount": "20.00",
       "currency_code": "USD"
     }
   },
-  "total_line_items_price": "24.00",
+  "total_line_items_price": "11.50",
   "total_line_items_price_set": {
     "shop_money": {
-      "amount": "24.00",
+      "amount": "11.50",
       "currency_code": "USD"
     },
     "presentment_money": {
-      "amount": "24.00",
+      "amount": "11.50",
       "currency_code": "USD"
     }
   },
-  "total_outstanding": "28.90",
-  "total_price": "28.90",
+  "total_outstanding": "11.50",
+  "total_price": "1.50",
   "total_price_set": {
     "shop_money": {
-      "amount": "28.90",
+      "amount": "1.50",
       "currency_code": "USD"
     },
     "presentment_money": {
-      "amount": "28.90",
+      "amount": "1.50",
       "currency_code": "USD"
     }
   },
   "total_shipping_price_set": {
     "shop_money": {
-      "amount": "4.90",
+      "amount": "10.00",
       "currency_code": "USD"
     },
     "presentment_money": {
-      "amount": "4.90",
+      "amount": "10.00",
       "currency_code": "USD"
     }
   },
@@ -169,43 +168,66 @@
     }
   },
   "total_tip_received": "0.00",
-  "total_weight": 474,
-  "updated_at": "2024-06-19T18:29:14+01:00",
+  "total_weight": 0,
+  "updated_at": "2024-06-30T20:13:52+01:00",
   "user_id": null,
   "billing_address": {
-    "province": "Tennessee",
+    "first_name": "Steve",
+    "address1": "123 Shipping Street",
+    "phone": "555-555-SHIP",
+    "city": "Shippington",
+    "zip": "40003",
+    "province": "Kentucky",
     "country": "United States",
+    "last_name": "Shipper",
+    "address2": null,
+    "company": "Shipping Company",
+    "latitude": null,
+    "longitude": null,
+    "name": "Steve Shipper",
     "country_code": "US",
-    "province_code": "TN"
+    "province_code": "KY"
   },
   "customer": {
-    "id": 7345180737748,
-    "created_at": "2024-06-19T18:29:11+01:00",
-    "updated_at": "2024-06-19T18:29:14+01:00",
+    "id": 115310627314723954,
+    "email": "john@example.com",
+    "created_at": null,
+    "updated_at": null,
+    "first_name": "John",
+    "last_name": "Smith",
     "state": "disabled",
     "note": null,
     "verified_email": true,
     "multipass_identifier": null,
     "tax_exempt": false,
+    "phone": null,
     "email_marketing_consent": {
       "state": "not_subscribed",
-      "opt_in_level": "single_opt_in",
+      "opt_in_level": null,
       "consent_updated_at": null
     },
     "sms_marketing_consent": null,
     "tags": "",
     "currency": "USD",
     "tax_exemptions": [],
-    "admin_graphql_api_id": "gid://shopify/Customer/7345180737748",
+    "admin_graphql_api_id": "gid:\/\/shopify\/Customer\/115310627314723954",
     "default_address": {
-      "id": 8919793270996,
-      "customer_id": 7345180737748,
+      "id": 715243470612851245,
+      "customer_id": 115310627314723954,
+      "first_name": null,
+      "last_name": null,
       "company": null,
-      "province": "Tennessee",
-      "country": "United States",
-      "province_code": "TN",
-      "country_code": "US",
-      "country_name": "United States",
+      "address1": "123 Elm St.",
+      "address2": null,
+      "city": "Ottawa",
+      "province": "Ontario",
+      "country": "Canada",
+      "zip": "K2H7A8",
+      "phone": "123-123-1234",
+      "name": "",
+      "province_code": "ON",
+      "country_code": "CA",
+      "country_name": "Canada",
       "default": true
     }
   },
@@ -213,35 +235,40 @@
   "fulfillments": [],
   "line_items": [
     {
-      "id": 13868670189780,
-      "admin_graphql_api_id": "gid://shopify/LineItem/13868670189780",
-      "attributed_staffs": [],
-      "current_quantity": 3,
-      "fulfillable_quantity": 3,
+      "id": 866550311766439020,
+      "admin_graphql_api_id": "gid:\/\/shopify\/LineItem\/866550311766439020",
+      "attributed_staffs": [
+        {
+          "id": "gid:\/\/shopify\/StaffMember\/902541635",
+          "quantity": 1
+        }
+      ],
+      "current_quantity": 1,
+      "fulfillable_quantity": 1,
       "fulfillment_service": "manual",
       "fulfillment_status": null,
       "gift_card": false,
-      "grams": 159,
-      "name": "Fashion Forward Socks",
-      "price": "8.00",
+      "grams": 340,
+      "name": "Totally Secure Moleskine® Notebook",
+      "price": "11.00",
       "price_set": {
         "shop_money": {
-          "amount": "8.00",
+          "amount": "11.00",
           "currency_code": "USD"
         },
         "presentment_money": {
-          "amount": "8.00",
+          "amount": "11.00",
           "currency_code": "USD"
         }
       },
       "product_exists": true,
-      "product_id": 8494449066196,
+      "product_id": 8494448771284,
       "properties": [],
-      "quantity": 3,
+      "quantity": 1,
       "requires_shipping": true,
-      "sku": "TARI_LOGOSOCKS",
+      "sku": "TARI_NOTEBOOK1",
       "taxable": true,
-      "title": "Fashion Forward Socks",
+      "title": "Totally Secure Moleskine® Notebook",
       "total_discount": "0.00",
       "total_discount_set": {
         "shop_money": {
@@ -253,10 +280,59 @@
           "currency_code": "USD"
         }
       },
-      "variant_id": 45280616513748,
+      "variant_id": 45280616054996,
       "variant_inventory_management": "shopify",
       "variant_title": null,
-      "vendor": "The TTL Store",
+      "vendor": null,
+      "tax_lines": [],
+      "duties": [],
+      "discount_allocations": []
+    },
+    {
+      "id": 141249953214522974,
+      "admin_graphql_api_id": "gid:\/\/shopify\/LineItem\/141249953214522974",
+      "attributed_staffs": [],
+      "current_quantity": 1,
+      "fulfillable_quantity": 1,
+      "fulfillment_service": "manual",
+      "fulfillment_status": null,
+      "gift_card": false,
+      "grams": 11,
+      "name": "Tari Sticker Sheet",
+      "price": "0.50",
+      "price_set": {
+        "shop_money": {
+          "amount": "0.50",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "0.50",
+          "currency_code": "USD"
+        }
+      },
+      "product_exists": true,
+      "product_id": 8494448935124,
+      "properties": [],
+      "quantity": 1,
+      "requires_shipping": true,
+      "sku": "TARI_STICKERSHEET1",
+      "taxable": true,
+      "title": "Tari Sticker Sheet",
+      "total_discount": "0.00",
+      "total_discount_set": {
+        "shop_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        }
+      },
+      "variant_id": 45280616218836,
+      "variant_inventory_management": "shopify",
+      "variant_title": null,
+      "vendor": null,
       "tax_lines": [],
       "duties": [],
       "discount_allocations": []
@@ -265,43 +341,54 @@
   "payment_terms": null,
   "refunds": [],
   "shipping_address": {
-    "province": "Tennessee",
+    "first_name": "Steve",
+    "address1": "123 Shipping Street",
+    "phone": "555-555-SHIP",
+    "city": "Shippington",
+    "zip": "40003",
+    "province": "Kentucky",
     "country": "United States",
+    "last_name": "Shipper",
+    "address2": null,
+    "company": "Shipping Company",
+    "latitude": null,
+    "longitude": null,
+    "name": "Steve Shipper",
     "country_code": "US",
-    "province_code": "TN"
+    "province_code": "KY"
   },
   "shipping_lines": [
     {
-      "id": 4545044185300,
-      "carrier_identifier": "650f1a14fa979ec5c74d063e968411d4",
-      "code": "Economy",
-      "discounted_price": "4.90",
+      "id": 271878346596884015,
+      "carrier_identifier": null,
+      "code": null,
+      "discounted_price": "10.00",
       "discounted_price_set": {
         "shop_money": {
-          "amount": "4.90",
+          "amount": "10.00",
           "currency_code": "USD"
         },
         "presentment_money": {
-          "amount": "4.90",
+          "amount": "10.00",
           "currency_code": "USD"
         }
       },
       "is_removed": false,
       "phone": null,
-      "price": "4.90",
+      "price": "10.00",
       "price_set": {
         "shop_money": {
-          "amount": "4.90",
+          "amount": "10.00",
           "currency_code": "USD"
         },
         "presentment_money": {
-          "amount": "4.90",
+          "amount": "10.00",
           "currency_code": "USD"
         }
       },
       "requested_fulfillment_service_id": null,
       "source": "shopify",
-      "title": "Economy",
+      "title": "Generic Shipping",
       "tax_lines": [],
       "discount_allocations": []
     }

--- a/tari_payment_engine/src/db_types.rs
+++ b/tari_payment_engine/src/db_types.rs
@@ -319,11 +319,10 @@ impl Display for NewOrder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Order #{order_id} @ \"{customer_id}\". {total_price}{currency} ({created_at})",
+            "Order #{order_id} @ \"{customer_id}\". {total_price} ({created_at})",
             order_id = self.order_id,
             customer_id = self.customer_id,
             total_price = self.total_price,
-            currency = self.currency,
             created_at = self.created_at
         )
     }

--- a/tari_payment_engine/src/sqlite/db/orders.rs
+++ b/tari_payment_engine/src/sqlite/db/orders.rs
@@ -39,7 +39,7 @@ async fn insert_order(order: NewOrder, conn: &mut SqliteConnection) -> Result<i6
     .bind(order.order_id)
     .bind(order.customer_id)
     .bind(order.memo)
-    .bind(order.total_price)
+    .bind(order.total_price.value())
     .bind(order.currency)
     .bind(order.created_at)
     .fetch_one(conn)

--- a/tari_payment_engine/src/tpe_api/exchange_objects.rs
+++ b/tari_payment_engine/src/tpe_api/exchange_objects.rs
@@ -7,29 +7,45 @@ use tpg_common::MicroTari;
 #[derive(Debug, Clone, FromRow)]
 pub struct ExchangeRate {
     pub base_currency: String,
-    /// the exchange rate, in hundredths of the base unit (i.e. rate = 100 is a 1:1 exchange rate)
-    pub rate: i64,
+    /// the exchange rate, in hundredths of the base unit (i.e. how many Tari in one cent of the base currency)
+    pub rate: MicroTari,
     pub updated_at: DateTime<Utc>,
 }
 
 impl ExchangeRate {
     /// Create a new ExchangeRate object
     ///
-    /// *NB* The rate is in hundreds of the base unit (i.e. rate = 100 is a 1:1 exchange rate)
-    pub fn new(currency: String, rate: i64, updated_at: Option<DateTime<Utc>>) -> Self {
+    /// *NB* The rate is in hundreds of the base unit (i.e. how many microTari in one cent of the base currency)
+    pub fn new(currency: String, rate_per_cent: MicroTari, updated_at: Option<DateTime<Utc>>) -> Self {
         let updated_at = updated_at.unwrap_or_else(Utc::now);
-        Self { base_currency: currency, rate, updated_at }
+        Self { base_currency: currency, rate: rate_per_cent, updated_at }
+    }
+
+    /// Create a new ExchangeRate object with a rate of 1 base unit per Tari
+    pub fn parity(currency: String) -> Self {
+        Self::new(currency, MicroTari::from(10_000), None)
     }
 
     /// Convert an amount in the base currency to Tari
     pub fn convert_to_tari(&self, amount: i64) -> MicroTari {
-        MicroTari::from(amount * self.rate * 10_000)
+        self.rate * amount * 100
+    }
+
+    /// Convert an amount in base currency cents to Tari
+    pub fn convert_to_tari_from_cents(&self, cents: i64) -> MicroTari {
+        self.rate * cents
     }
 }
 
 impl Display for ExchangeRate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "1 {} => {} XTR", self.base_currency, self.rate / 100)
+        write!(f, "1 {} => {}", self.base_currency, self.rate * 100)
+    }
+}
+
+impl Default for ExchangeRate {
+    fn default() -> Self {
+        Self { base_currency: "XTR".to_string(), rate: MicroTari::from(10_000), updated_at: Utc::now() }
     }
 }
 
@@ -40,13 +56,25 @@ mod test {
     #[test]
     fn test_exchange_rate() {
         // 1:1 exchange rate
-        let rate = ExchangeRate::new("USD".to_string(), 100, None);
-        assert_eq!(rate.convert_to_tari(100), MicroTari::from_tari(100));
-        assert_eq!(format!("{rate}"), "1 USD => 1 XTR");
+        let rate = ExchangeRate::default();
+        assert_eq!(rate.convert_to_tari(5), MicroTari::from_tari(5));
+        assert_eq!(rate.convert_to_tari_from_cents(50), MicroTari::from(500_000));
+        assert_eq!(format!("{rate}"), "1 XTR => 1.000τ");
 
-        // 1 XTR : 2c
-        let rate = ExchangeRate::new("USD".to_string(), 5000, None);
+        // 5000 XTR/$
+        let rate = ExchangeRate::new("USD".to_string(), MicroTari::from_tari(50), None);
+        assert_eq!(rate.convert_to_tari(5), MicroTari::from_tari(25_000));
+        assert_eq!(rate.convert_to_tari_from_cents(2), MicroTari::from_tari(100));
+        assert_eq!(format!("{rate}"), "1 USD => 5000.000τ");
+
+        // 1 XTR : 2c (1c => 500,000 microTari)
+        let rate = ExchangeRate::new("USD".to_string(), MicroTari::from(500_000), None);
         assert_eq!(rate.convert_to_tari(1), MicroTari::from_tari(50));
-        assert_eq!(format!("{rate}"), "1 USD => 50 XTR");
+        assert_eq!(format!("{rate}"), "1 USD => 50.000τ");
+
+        // 1 XTR = $1
+        let rate = ExchangeRate::parity("USD".to_string());
+        assert_eq!(rate.convert_to_tari(1), MicroTari::from_tari(1));
+        assert_eq!(format!("{rate}"), "1 USD => 1.000τ");
     }
 }

--- a/tari_payment_server/src/data_objects.rs
+++ b/tari_payment_server/src/data_objects.rs
@@ -91,13 +91,14 @@ pub struct AttachOrderParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExchangeRateUpdate {
     pub currency: String,
+    // The Tari price in MicroTari per 1c of base currency
     pub rate: u64,
 }
 
 impl From<ExchangeRateUpdate> for ExchangeRate {
     fn from(update: ExchangeRateUpdate) -> Self {
         #[allow(clippy::cast_possible_wrap)]
-        Self::new(update.currency, update.rate as i64, None)
+        Self::new(update.currency, MicroTari::from(update.rate as i64), None)
     }
 }
 
@@ -110,6 +111,6 @@ pub struct ExchangeRateResult {
 
 impl From<ExchangeRate> for ExchangeRateResult {
     fn from(rate: ExchangeRate) -> Self {
-        Self { currency: rate.base_currency, rate: rate.rate / 100, updated_at: rate.updated_at.to_rfc3339() }
+        Self { currency: rate.base_currency, rate: rate.rate.value(), updated_at: rate.updated_at.to_rfc3339() }
     }
 }

--- a/tari_payment_server/src/integrations/shopify.rs
+++ b/tari_payment_server/src/integrations/shopify.rs
@@ -4,9 +4,11 @@ use shopify_tools::ShopifyOrder;
 use tari_payment_engine::{
     db_types::{NewOrder, OrderId},
     helpers::MemoSignatureError,
+    tpe_api::{exchange_objects::ExchangeRate, exchange_rate_api::ExchangeRateApi},
+    traits::ExchangeRates,
 };
 use thiserror::Error;
-use tpg_common::{MicroTari, TARI_CURRENCY_CODE_LOWER};
+use tpg_common::TARI_CURRENCY_CODE;
 
 #[derive(Debug, Error)]
 #[error("Could not convert shopify order into a new order. {0}.")]
@@ -19,23 +21,30 @@ pub enum OrderConversionError {
     InvalidMemoSignature(#[from] MemoSignatureError),
 }
 
-pub fn new_order_from_shopify_order(value: ShopifyOrder) -> Result<NewOrder, OrderConversionError> {
+pub async fn new_order_from_shopify_order<B: ExchangeRates>(
+    value: ShopifyOrder,
+    fx: &ExchangeRateApi<B>,
+) -> Result<NewOrder, OrderConversionError> {
     trace!("Converting ShopifyOrder to NewOrder: {:?}", value);
-    if value.currency.as_str().to_lowercase() != TARI_CURRENCY_CODE_LOWER {
-        return Err(OrderConversionError::UnsupportedCurrency(value.currency));
-    }
-    let total_price = value
-        .total_price
-        .parse::<u64>()
-        .map_err(|e| OrderConversionError::FormatError(e.to_string()))
-        .map(MicroTari::try_from)?
-        .map_err(|e| OrderConversionError::FormatError(e.to_string()))?;
-
+    let currency = value.currency.as_str().to_uppercase();
+    let rate = if currency != TARI_CURRENCY_CODE {
+        let rate = fx
+            .fetch_last_rate(&currency)
+            .await
+            .map_err(|e| OrderConversionError::UnsupportedCurrency(e.to_string()))?;
+        info!("Shopify order is not in Tari. Using a conversion rate of {rate}");
+        rate
+    } else {
+        ExchangeRate::default()
+    };
+    // Net price in cents.
+    let total_price = parse_shopify_price(&value.total_price)?;
+    let total_price = rate.convert_to_tari_from_cents(total_price);
     let timestamp =
         value.created_at.parse::<DateTime<Utc>>().map_err(|e| OrderConversionError::FormatError(e.to_string()))?;
     let memo = value.note;
     let mut order = NewOrder {
-        order_id: OrderId(value.name),
+        order_id: OrderId(value.id.to_string()),
         customer_id: value.customer.id.to_string(),
         currency: value.currency,
         memo,
@@ -51,4 +60,20 @@ pub fn new_order_from_shopify_order(value: ShopifyOrder) -> Result<NewOrder, Ord
         );
     }
     Ok(order)
+}
+
+/// Shopify uses floating point number expressed as strings.
+fn parse_shopify_price(price: &str) -> Result<i64, OrderConversionError> {
+    let mut parts = price.split('.');
+    let whole_units = parts
+        .next()
+        .ok_or_else(|| OrderConversionError::FormatError(format!("Empty price in shopify order: {price}")))?
+        .parse::<i64>()
+        .map_err(|e| OrderConversionError::FormatError(e.to_string()))?;
+    let cents = parts
+        .next()
+        .map(|s| s.parse::<i64>())
+        .unwrap_or(Ok(0))
+        .map_err(|e| OrderConversionError::FormatError(e.to_string()))?;
+    Ok(100 * whole_units + cents)
 }

--- a/tari_payment_server/src/middleware/hmac.rs
+++ b/tari_payment_server/src/middleware/hmac.rs
@@ -90,11 +90,11 @@ where
         Box::pin(async move {
             trace!("🔐️ Checking HMAC for request");
             if !enabled {
-                trace!("HMAC checks are disabled. Allowing request.");
+                trace!("🔐️ HMAC checks are disabled. Allowing request.");
                 return service.call(req).await;
             }
             let data = req.extract::<web::Bytes>().await.map_err(|e| {
-                warn!("Failed to extract request data: {:?}", e);
+                warn!("🔐️ Failed to extract request data: {:?}", e);
                 ErrorBadRequest("Failed to extract request data.")
             })?;
             let hmac_calc = calculate_hmac(&secret, data.as_ref());
@@ -104,10 +104,11 @@ where
             })?;
             let validated = hmac == hmac_calc.as_str();
             if validated {
+                trace!("🔐️ HMAC check for request ✅️");
                 req.set_payload(bytes_to_payload(data));
                 service.call(req).await
             } else {
-                warn!("Invalid HMAC signature found in request. denying access.");
+                warn!("🔐️ Invalid HMAC signature found in request. denying access.");
                 Err(ErrorForbidden("Invalid HMAC signature."))
             }
         })

--- a/tari_payment_server/src/server.rs
+++ b/tari_payment_server/src/server.rs
@@ -108,7 +108,7 @@ pub fn create_server_instance(
         let exchange_rates = ExchangeRateApi::new(db.clone());
         let hmac_middleware = HmacMiddlewareFactory::new(
             "X-Shopify-Hmac-Sha256",
-            config.shopify_api_secret.clone(),
+            config.shopify_hmac_secret.clone(),
             config.shopify_hmac_checks,
         );
 
@@ -159,7 +159,7 @@ pub fn create_server_instance(
                 }
             })
             .wrap(hmac_middleware)
-            .service(ShopifyWebhookRoute::<SqliteDatabase>::new())
+            .service(ShopifyWebhookRoute::<SqliteDatabase, SqliteDatabase>::new())
             .service(health);
         let wallet_scope = web::scope("/wallet")
             .service(IncomingPaymentNotificationRoute::<SqliteDatabase, SqliteDatabase>::new())

--- a/tpg_common/src/microtari.rs
+++ b/tpg_common/src/microtari.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Display,
     iter::Sum,
-    ops::{Add, Neg, Sub, SubAssign},
+    ops::{Add, Mul, Neg, Sub, SubAssign},
 };
 
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,14 @@ op!(binary MicroTari, Add, add);
 op!(binary MicroTari, Sub, sub);
 op!(inplace MicroTari, SubAssign, sub_assign);
 op!(unary MicroTari, Neg, neg);
+
+impl Mul<i64> for MicroTari {
+    type Output = Self;
+
+    fn mul(self, rhs: i64) -> Self::Output {
+        Self::from(self.value() * rhs)
+    }
+}
 
 impl Sum for MicroTari {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {


### PR DESCRIPTION
Convert incoming order notifications that are not denominated in XTR to their Tari equivalent using the exchange rate table.