### PR TITLE
feat: cancel shopify order

### DIFF
--- a/shopify_tools/src/api.rs
+++ b/shopify_tools/src/api.rs
@@ -98,6 +98,18 @@ impl ShopifyApi {
         Ok(result.order)
     }
 
+    pub async fn cancel_order(&self, order_id: u64) -> Result<ShopifyOrder, ShopifyApiError> {
+        #[derive(Deserialize)]
+        struct OrderResponse {
+            order: ShopifyOrder,
+        }
+        let path = format!("/orders/{order_id}/cancel.json");
+        debug!("Cancelling order #{order_id}");
+        let result = self.rest_query::<OrderResponse, ()>(Method::POST, &path, &[], None).await?;
+        debug!("Cancelled order #{order_id}");
+        Ok(result.order)
+    }
+
     pub async fn get_exchange_rates(&self) -> Result<ExchangeRates, ShopifyApiError> {
         let query = r#"{
           metaobjectByHandle(handle: {type: "tari_price", handle: "tari-price-global"}) {

--- a/taritools/src/shopify/command_def.rs
+++ b/taritools/src/shopify/command_def.rs
@@ -19,6 +19,11 @@ pub enum OrdersCommand {
         #[arg(required = true, index = 1)]
         id: u64,
     },
+    /// Cacnel the order with the given ID
+    Cancel {
+        #[arg(required = true, index = 1)]
+        id: u64,
+    },
     /// Modify the order
     Modify,
 }

--- a/taritools/src/shopify/command_handler.rs
+++ b/taritools/src/shopify/command_handler.rs
@@ -7,6 +7,7 @@ pub async fn handle_shopify_command(command: ShopifyCommand) {
     match command {
         Orders(orders_command) => match orders_command {
             OrdersCommand::Get { id } => fetch_shopify_order(id).await,
+            OrdersCommand::Cancel { id } => cancel_shopify_order(id).await,
             OrdersCommand::Modify => {
                 println!("Modifying order");
             },
@@ -38,6 +39,19 @@ pub async fn fetch_shopify_order(id: u64) {
         },
         Err(e) => {
             eprintln!("Error fetching order #{id}: {e}");
+        },
+    }
+}
+
+pub async fn cancel_shopify_order(id: u64) {
+    let api = new_shopify_api();
+    match api.cancel_order(id).await {
+        Ok(order) => {
+            let json = serde_json::to_string_pretty(&order).unwrap();
+            println!("Cancelled order #{id}\n{json}");
+        },
+        Err(e) => {
+            eprintln!("Error cancelling order #{id}: {e}");
         },
     }
 }


### PR DESCRIPTION
Adds an API call and a CLI command to cancel a shopify order