### PR TITLE
feat: mark shopify order as paid

### DIFF
--- a/shopify_tools/src/lib.rs
+++ b/shopify_tools/src/lib.rs
@@ -2,6 +2,7 @@ mod api;
 mod config;
 mod error;
 mod shopify_order;
+mod shopify_transaction;
 
 mod data_objects;
 
@@ -10,3 +11,4 @@ pub use config::ShopifyConfig;
 pub use data_objects::{ExchangeRate, ExchangeRates};
 pub use error::ShopifyApiError;
 pub use shopify_order::{Customer, EmailMarketingConsent, OrderBuilder, ShopifyOrder};
+pub use shopify_transaction::{CurrencyExchangeAdjustment, OutstandingValue, ShopifyTransaction};

--- a/shopify_tools/src/shopify_transaction.rs
+++ b/shopify_tools/src/shopify_transaction.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct ShopifyTransaction {
+    pub id: i64,
+    pub order_id: i64,
+    pub amount: String,
+    pub authorization: Option<String>,
+    pub authorization_expires_at: Option<String>,
+    pub created_at: String,
+    pub currency: String,
+    pub device_id: Option<i64>,
+    pub error_code: Option<String>,
+    pub gateway: Option<String>,
+    pub kind: String,
+    pub message: String,
+    pub parent_id: i64,
+    pub processed_at: String,
+    pub source_name: String,
+    pub status: String,
+    pub total_unsettled_set: TotalUnsettledSet,
+    pub test: bool,
+    pub user_id: Option<i64>,
+    pub currency_exchange_adjustment: Option<CurrencyExchangeAdjustment>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CurrencyExchangeAdjustment {
+    pub id: i64,
+    pub adjustment: String,
+    pub original_amount: String,
+    pub final_amount: String,
+    pub currency: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct OutstandingValue {
+    pub amount: String,
+    pub currency: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TotalUnsettledSet {
+    pub presentment_money: OutstandingValue,
+    pub shop_money: OutstandingValue,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_shopify_transaction() {
+        let json = include_str!("./test_assets/transaction1.json");
+        let tx: ShopifyTransaction = serde_json::from_str(json).unwrap();
+        assert_eq!(tx.amount, "6.00");
+        assert_eq!(tx.id, 6674280546516);
+    }
+}

--- a/shopify_tools/src/test_assets/transaction1.json
+++ b/shopify_tools/src/test_assets/transaction1.json
@@ -1,0 +1,34 @@
+{
+  "admin_graphql_api_id": "gid://shopify/OrderTransaction/6674280546516",
+  "amount": "6.00",
+  "authorization": null,
+  "created_at": "2024-07-01T13:44:10+01:00",
+  "currency": "USD",
+  "device_id": null,
+  "error_code": null,
+  "gateway": "Tari Payment Server",
+  "id": 6674280546516,
+  "kind": "sale",
+  "location_id": null,
+  "manual_payment_gateway": true,
+  "message": "Marked the Tari Payment Server payment as received",
+  "order_id": 5628558835924,
+  "parent_id": 6667516969172,
+  "payment_id": "#1017.3",
+  "processed_at": "2024-07-01T13:44:10+01:00",
+  "receipt": {},
+  "source_name": "132659281921",
+  "status": "success",
+  "test": false,
+  "total_unsettled_set": {
+    "presentment_money": {
+      "amount": "0.0",
+      "currency": "USD"
+    },
+    "shop_money": {
+      "amount": "0.0",
+      "currency": "USD"
+    }
+  },
+  "user_id": null
+}

--- a/taritools/src/shopify/command_def.rs
+++ b/taritools/src/shopify/command_def.rs
@@ -24,6 +24,16 @@ pub enum OrdersCommand {
         #[arg(required = true, index = 1)]
         id: u64,
     },
+    /// Mark the given order as paid on Shopify. This does not facilitate any transfer of funds; it only tells Shopify
+    /// that the order has been paid for.
+    Pay {
+        #[arg(required = true, index = 1)]
+        id: u64,
+        #[arg(required = true, index = 2)]
+        amount: String,
+        #[arg(required = true, index = 3)]
+        currency: String,
+    },
     /// Modify the order
     Modify,
 }

--- a/taritools/src/shopify/command_handler.rs
+++ b/taritools/src/shopify/command_handler.rs
@@ -8,6 +8,7 @@ pub async fn handle_shopify_command(command: ShopifyCommand) {
         Orders(orders_command) => match orders_command {
             OrdersCommand::Get { id } => fetch_shopify_order(id).await,
             OrdersCommand::Cancel { id } => cancel_shopify_order(id).await,
+            OrdersCommand::Pay { id, amount, currency } => mark_order_as_paid(id, amount, currency).await,
             OrdersCommand::Modify => {
                 println!("Modifying order");
             },
@@ -52,6 +53,19 @@ pub async fn cancel_shopify_order(id: u64) {
         },
         Err(e) => {
             eprintln!("Error cancelling order #{id}: {e}");
+        },
+    }
+}
+
+pub async fn mark_order_as_paid(id: u64, amount: String, currency: String) {
+    let api = new_shopify_api();
+    match api.mark_order_as_paid(id, amount, currency).await {
+        Ok(tx) => {
+            let json = serde_json::to_string_pretty(&tx).unwrap();
+            println!("Marked order #{id} as paid\n{json}");
+        },
+        Err(e) => {
+            eprintln!("Error marking order #{id} as paid: {e}");
         },
     }
 }


### PR DESCRIPTION
Adds an API method and a CLI command to mark a payment against a shopify order.