### PR TITLE
feat: set tari price

### DIFF
--- a/shopify_tools/src/error.rs
+++ b/shopify_tools/src/error.rs
@@ -16,4 +16,6 @@ pub enum ShopifyApiError {
     InvalidGraphQL(String),
     #[error("GraphQL query failed: {0}")]
     GraphQLError(String),
+    #[error("Invalid currency amount: {0}")]
+    InvalidCurrencyAmount(String),
 }

--- a/shopify_tools/src/helpers.rs
+++ b/shopify_tools/src/helpers.rs
@@ -1,0 +1,23 @@
+use tpg_common::MicroTari;
+
+use crate::ShopifyApiError;
+
+/// Shopify uses floating point number expressed as strings.
+pub fn parse_shopify_price(price: &str) -> Result<i64, ShopifyApiError> {
+    let mut parts = price.split('.');
+    let whole_units = parts
+        .next()
+        .ok_or_else(|| ShopifyApiError::InvalidCurrencyAmount(price.to_string()))?
+        .parse::<i64>()
+        .map_err(|e| ShopifyApiError::InvalidCurrencyAmount(format!("Invalid price value: {price}. {e}.")))?;
+    let cents = parts
+        .next()
+        .map(|s| s.parse::<i64>())
+        .unwrap_or(Ok(0))
+        .map_err(|e| ShopifyApiError::InvalidCurrencyAmount(format!("Invalid price value: {price}. {e}.")))?;
+    Ok(100 * whole_units + cents)
+}
+
+pub fn tari_shopify_price(p: MicroTari) -> String {
+    format!("{}", p.value())
+}

--- a/shopify_tools/src/lib.rs
+++ b/shopify_tools/src/lib.rs
@@ -6,6 +6,8 @@ mod shopify_transaction;
 
 pub mod data_objects;
 
+pub mod helpers;
+
 pub use api::ShopifyApi;
 pub use config::ShopifyConfig;
 pub use data_objects::{ExchangeRate, ExchangeRates};

--- a/taritools/src/shopify/command_def.rs
+++ b/taritools/src/shopify/command_def.rs
@@ -45,6 +45,13 @@ pub enum OrdersCommand {
 pub enum ProductsCommand {
     /// Fetch all product variants with their Tari prices
     All,
+    #[command(name = "update-price")]
+    /// Updates prices for all products using the given exchange rates
+    UpdatePrice {
+        #[arg(required = true, index = 1)]
+        /// The exchange rates to use for updating the prices in microTari per cent of the base currency
+        microtari_per_cent: i64,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/taritools/src/shopify/command_handler.rs
+++ b/taritools/src/shopify/command_handler.rs
@@ -23,6 +23,7 @@ pub async fn handle_shopify_command(command: ShopifyCommand) {
         },
         Products(products_cmd) => match products_cmd {
             ProductsCommand::All => fetch_all_variants().await,
+            ProductsCommand::UpdatePrice { microtari_per_cent } => update_prices(microtari_per_cent).await,
         },
     }
 }
@@ -110,6 +111,28 @@ pub async fn fetch_all_variants() {
         Ok(variants) => {
             let json = serde_json::to_string_pretty(&variants).unwrap();
             println!("Variants\n{json}");
+        },
+        Err(e) => {
+            eprintln!("Error fetching variants: {e}");
+        },
+    }
+}
+
+pub async fn update_prices(rate: i64) {
+    let api = new_shopify_api();
+    match api.fetch_all_variants().await {
+        Ok(variants) => {
+            let rate = ExchangeRate::new("USD".to_string(), rate.into());
+            match api.update_tari_price(variants, rate).await {
+                Ok(products) => {
+                    println!("Prices updated");
+                    let json = serde_json::to_string_pretty(&products).unwrap();
+                    println!("Updated products:\n{json}");
+                },
+                Err(e) => {
+                    eprintln!("Error updating prices: {e}");
+                },
+            }
         },
         Err(e) => {
             eprintln!("Error fetching variants: {e}");


### PR DESCRIPTION
Adds a CLI command to set the tari_price as a metafield on all products based on a given exchange rate.

the Tari store theme **should** use `product.variant.custom.tari_price | divided_by: 1000000` to get the product price in Tari on product pages, cart etc.