### PR TITLE
feat: tui tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
  "nom",
  "pathdiff",
  "serde",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -795,7 +795,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
  "unicode-width",
@@ -938,6 +938,27 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1166,6 +1187,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "fuzzy-matcher",
+ "shell-words",
+ "thiserror",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1227,28 @@ checksum = "cf36e65a80337bea855cd4ef9b8401ffce06a7baedf2e85ec467b1ac3f6e82b6"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1260,6 +1324,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1527,6 +1597,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1995,6 +2074,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "inflections"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,6 +2102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,6 +2121,17 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2448,6 +2560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2633,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -2755,6 +2879,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode 1.0.0",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2773,7 +2911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2782,7 +2920,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -3117,6 +3255,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3229,6 +3373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,6 +3449,12 @@ dependencies = [
  "digest",
  "keccak",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shopify_tools"
@@ -3860,7 +4019,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "config",
- "dirs-next",
+ "dirs-next 1.0.2",
  "log",
  "multiaddr",
  "path-clean",
@@ -4009,12 +4168,18 @@ dependencies = [
 name = "taritools"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap 4.5.4",
+ "dialoguer",
+ "dirs",
  "dotenvy",
  "env_logger",
+ "indicatif",
  "log",
+ "prettytable-rs",
  "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
  "shopify_tools",
@@ -4025,6 +4190,7 @@ dependencies = [
  "tari_payment_engine",
  "tari_payment_server",
  "tokio",
+ "toml 0.8.14",
  "tpg_common",
 ]
 
@@ -4038,6 +4204,17 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next 2.0.0",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -4114,6 +4291,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
 dependencies = [
  "thiserror-impl-no-std",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -4247,10 +4434,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.15",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -4260,7 +4462,20 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.2.6",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -4824,6 +5039,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]

--- a/shopify_tools/src/api.rs
+++ b/shopify_tools/src/api.rs
@@ -22,6 +22,7 @@ use crate::{
     ShopifyTransaction,
 };
 
+#[derive(Clone)]
 pub struct ShopifyApi {
     config: ShopifyConfig,
     client: Arc<Client>,
@@ -242,8 +243,8 @@ impl ShopifyApi {
         let mut result = vec![];
         debug!("Updating prices for {} product variants", products.len());
         for product in products {
-            let shop_price = parse_shopify_price(&product.price)?;
-            let tari_price = tari_shopify_price(MicroTari::from(rate * shop_price));
+            let shop_price_in_cents = parse_shopify_price(&product.price)?;
+            let tari_price = tari_shopify_price(MicroTari::from(rate * shop_price_in_cents / 100));
             if let Some(mf) = &product.metafield {
                 if mf.value == tari_price {
                     info!(

--- a/tari_payment_engine/src/sqlite/db/auth.rs
+++ b/tari_payment_engine/src/sqlite/db/auth.rs
@@ -95,7 +95,7 @@ pub async fn upsert_nonce_for_address(
     #[allow(clippy::cast_possible_wrap)]
     let nonce = nonce as i64;
     let res = sqlx::query!(
-        r#"INSERT INTO auth_log (address, last_nonce) VALUES (?, ?) ON CONFLICT(address) DO
+        r#"INSERT INTO auth_log (last_nonce, address) VALUES (?, ?) ON CONFLICT(address) DO
     UPDATE SET last_nonce = excluded.last_nonce"#,
         nonce,
         address

--- a/tari_payment_engine/src/tpe_api/exchange_objects.rs
+++ b/tari_payment_engine/src/tpe_api/exchange_objects.rs
@@ -23,29 +23,29 @@ impl ExchangeRate {
 
     /// Create a new ExchangeRate object with a rate of 1 base unit per Tari
     pub fn parity(currency: String) -> Self {
-        Self::new(currency, MicroTari::from(10_000), None)
+        Self::new(currency, MicroTari::from_tari(1), None)
     }
 
     /// Convert an amount in the base currency to Tari
     pub fn convert_to_tari(&self, amount: i64) -> MicroTari {
-        self.rate * amount * 100
+        self.rate * amount
     }
 
     /// Convert an amount in base currency cents to Tari
     pub fn convert_to_tari_from_cents(&self, cents: i64) -> MicroTari {
-        self.rate * cents
+        MicroTari::from(self.rate.value() * cents / 100)
     }
 }
 
 impl Display for ExchangeRate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "1 {} => {}", self.base_currency, self.rate * 100)
+        write!(f, "1 {} => {}", self.base_currency, self.rate)
     }
 }
 
 impl Default for ExchangeRate {
     fn default() -> Self {
-        Self { base_currency: "XTR".to_string(), rate: MicroTari::from(10_000), updated_at: Utc::now() }
+        Self { base_currency: "XTR".to_string(), rate: MicroTari::from_tari(1), updated_at: Utc::now() }
     }
 }
 
@@ -63,14 +63,14 @@ mod test {
 
         // 5000 XTR/$
         let rate = ExchangeRate::new("USD".to_string(), MicroTari::from_tari(50), None);
-        assert_eq!(rate.convert_to_tari(5), MicroTari::from_tari(25_000));
-        assert_eq!(rate.convert_to_tari_from_cents(2), MicroTari::from_tari(100));
-        assert_eq!(format!("{rate}"), "1 USD => 5000.000τ");
+        assert_eq!(rate.convert_to_tari(5), MicroTari::from_tari(250));
+        assert_eq!(rate.convert_to_tari_from_cents(2), MicroTari::from_tari(1));
+        assert_eq!(format!("{rate}"), "1 USD => 50.000τ");
 
         // 1 XTR : 2c (1c => 500,000 microTari)
         let rate = ExchangeRate::new("USD".to_string(), MicroTari::from(500_000), None);
-        assert_eq!(rate.convert_to_tari(1), MicroTari::from_tari(50));
-        assert_eq!(format!("{rate}"), "1 USD => 50.000τ");
+        assert_eq!(rate.convert_to_tari(1), MicroTari::from(500_000));
+        assert_eq!(format!("{rate}"), "1 USD => 0.500τ");
 
         // 1 XTR = $1
         let rate = ExchangeRate::parity("USD".to_string());

--- a/tari_payment_server/src/data_objects.rs
+++ b/tari_payment_server/src/data_objects.rs
@@ -91,7 +91,7 @@ pub struct AttachOrderParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExchangeRateUpdate {
     pub currency: String,
-    // The Tari price in MicroTari per 1c of base currency
+    // The price of 1 unit of the currency in MicroTari
     pub rate: u64,
 }
 

--- a/tari_payment_server/src/routes.rs
+++ b/tari_payment_server/src/routes.rs
@@ -898,7 +898,9 @@ pub async fn update_shopify_exchange_rate<B: ExchangeRates>(
     shopify_api: web::Data<ShopifyApi>,
 ) -> Result<HttpResponse, ServerError> {
     let update = body.into_inner();
+    debug!("💻️ POST update exchange rate for {} to {}", update.currency, MicroTari::from(update.rate as i64));
     update_local_exchange_rate(update.clone(), api.as_ref()).await?;
+    debug!("💻️ Tari price has been updated in the database.");
     update_shopify_exchange_rate_for(&update, shopify_api.as_ref()).await?;
     Ok(HttpResponse::Ok().finish())
 }

--- a/taritools/Cargo.toml
+++ b/taritools/Cargo.toml
@@ -9,11 +9,17 @@ tari_payment_server = {version = "0.1.0", path = "../tari_payment_server"}
 tari_payment_engine = {version = "0.1.0", path = "../tari_payment_engine"}
 tpg_common = {version = "0.1.0", path = "../tpg_common"}
 
+anyhow = "1.0.44"
 chrono = "0.4.19"
 clap = { version = "4.5.3", features = ["derive"] }
+dirs = "5.0.1"
 dotenvy = "0.15.0"
 env_logger = "0.11.3"
+dialoguer = { version = "0.11.0", default-features = false, features = ["completion", "fuzzy-select", "history"] }
+indicatif = "0.17.8"
+prettytable-rs = "0.10.0"
 rand = "0.8.4"
+reqwest = { version = "0.12.2", features = ["json"] }
 tari_crypto = "0.20.0"
 tari_common = "1.0.0-rc.5"
 tari_common_types = "1.0.0-rc.5"
@@ -21,4 +27,5 @@ tari-jwt = {  version = "0.1.0", git = "https://github.com/tari-project/tari-jwt
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.117"
 tokio = "1.37.0"
+toml = "0.8.14"
 log = "0.4.21"

--- a/taritools/src/interactive.rs
+++ b/taritools/src/interactive.rs
@@ -1,0 +1,108 @@
+use std::{fmt::Display, time::Duration};
+
+use anyhow::Result;
+use dialoguer::{console::Style, theme::ColorfulTheme, Confirm, FuzzySelect};
+use indicatif::{ProgressBar, ProgressStyle};
+use prettytable::{row, Cell, Row, Table};
+use tari_payment_engine::db_types::UserAccount;
+use tari_payment_server::data_objects::ExchangeRateResult;
+use tpg_common::MicroTari;
+
+use crate::{
+    profile_manager::{read_config, Profile},
+    tari_payment_server::client::PaymentServerClient,
+};
+
+pub const COMMANDS: [&str; 6] =
+    ["Authenticate", "Exit", "My Account", "Server health", "Fetch Tari price", "Set Tari price"];
+
+pub async fn run() -> Result<()> {
+    let theme = ColorfulTheme { values_style: Style::new().yellow().dim(), ..ColorfulTheme::default() };
+    let profile = select_profile(&theme)?;
+    let mut client = PaymentServerClient::new(profile.clone());
+    loop {
+        let i = FuzzySelect::with_theme(&theme).with_prompt("Select command").items(&COMMANDS).interact()?;
+        match COMMANDS[i] {
+            "Authenticate" => handle_response(client.authenticate().await.map(|_| "Authenticated")),
+            "Server health" => handle_response(client.health().await),
+            "My Account" => handle_response(client.my_account().await.map(format_user_account)),
+            "Fetch Tari price" => handle_response(client.fetch_exchange_rates("USD").await.map(format_exchange_rate)),
+            "Set Tari price" => set_tari_price(&mut client).await?,
+            "Exit" => break,
+            _ => continue,
+        }
+    }
+    Ok(())
+}
+
+fn handle_response<T: Display>(res: Result<T>) {
+    match res {
+        Ok(res) => println!("{res}"),
+        Err(e) => println!("Error: {}", e),
+    }
+}
+
+async fn set_tari_price(client: &mut PaymentServerClient) -> Result<()> {
+    let rate = dialoguer::Input::<f64>::new().with_prompt("Enter Tari price (per USD)").interact()?;
+    let price = MicroTari::from((rate * 1e6) as i64);
+    if !Confirm::new().with_prompt(format!("Set Tari price to {price}?")).interact()? {
+        return Err(anyhow::anyhow!("Cancelled"));
+    }
+    let pb = ProgressBar::new_spinner();
+    pb.enable_steady_tick(Duration::from_millis(100));
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:5} {msg} [{elapsed}]").unwrap()
+            // For more spinners check out the cli-spinners project:
+            // https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json
+            .tick_strings(&[
+                "🕛 ",
+                "🕐 ",
+                "🕑 ",
+                "🕒 ",
+                "🕓 ",
+                "🕔 ",
+                "🕕 ",
+                "🕖 ",
+                "🕗 ",
+                "🕘 ",
+                "🕙 ",
+                "🕚 "
+            ]),
+    );
+    pb.set_message("Updating prices (this could take a few minutes)...");
+    let res = client.set_exchange_rate("USD", price).await;
+    pb.finish_with_message("Done!");
+    res
+}
+
+fn select_profile(theme: &ColorfulTheme) -> Result<Profile> {
+    let user_data = read_config()?;
+    let options = user_data.profiles.iter().map(|p| format!("{} ({})", p.name, p.server)).collect::<Vec<String>>();
+    let profile =
+        FuzzySelect::with_theme(theme).with_prompt("Select profile").items(&options).interact().and_then(|i| {
+            let profile = &user_data.profiles[i];
+            Ok(profile.clone())
+        })?;
+    Ok(profile)
+}
+
+fn format_user_account(account: UserAccount) -> String {
+    let mut table = Table::new();
+    table.add_row(row!["Field", "Value"]);
+    table.add_row(Row::new(vec![Cell::new("ID"), Cell::new(&account.id.to_string())]));
+    table.add_row(Row::new(vec![Cell::new("Created At"), Cell::new(&account.created_at.to_string())]));
+    table.add_row(Row::new(vec![Cell::new("Updated At"), Cell::new(&account.updated_at.to_string())]));
+    table.add_row(Row::new(vec![Cell::new("Total Received"), Cell::new(&account.total_received.to_string())]));
+    table.add_row(Row::new(vec![Cell::new("Current Pending"), Cell::new(&account.current_pending.to_string())]));
+    table.add_row(Row::new(vec![Cell::new("Current Balance"), Cell::new(&account.current_balance.to_string())]));
+    table.add_row(Row::new(vec![Cell::new("Total Orders"), Cell::new(&account.total_orders.to_string())]));
+    table.add_row(Row::new(vec![Cell::new("Current Orders"), Cell::new(&account.current_orders.to_string())]));
+
+    // Format the table to a string
+    table.to_string()
+}
+
+fn format_exchange_rate(rate: ExchangeRateResult) -> String {
+    let tari = MicroTari::from(rate.rate);
+    format!("1 {} => {tari} (Last update: {})", rate.currency, rate.updated_at)
+}

--- a/taritools/src/profile_manager.rs
+++ b/taritools/src/profile_manager.rs
@@ -1,0 +1,85 @@
+use std::{
+    fs,
+    io,
+    io::{Error, ErrorKind},
+    path::PathBuf,
+};
+
+use dirs::home_dir;
+use log::info;
+use serde::{Deserialize, Serialize};
+use tari_crypto::ristretto::RistrettoSecretKey;
+use tari_payment_engine::db_types::{Role, SerializedTariAddress};
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct UserData {
+    pub profiles: Vec<Profile>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Profile {
+    pub name: String,
+    pub address: SerializedTariAddress,
+    pub secret_key: RistrettoSecretKey,
+    pub roles: Vec<Role>,
+    pub server: String,
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        Profile {
+            name: "default".to_string(),
+            address: SerializedTariAddress::default(),
+            secret_key: RistrettoSecretKey::default(),
+            roles: vec![Role::User],
+            server: "http://localhost:4444".to_string(),
+        }
+    }
+}
+
+pub fn get_config_path() -> io::Result<PathBuf> {
+    let home = home_dir().ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Home directory not found"))?;
+    let config_dir = home.join(".taritools");
+    if !config_dir.exists() {
+        fs::create_dir(&config_dir)?;
+        set_permissions(&config_dir, 0o700)?;
+    }
+    let config_file = config_dir.join("config.toml");
+    if !config_file.exists() {
+        info!("Creating default config file");
+        let default_config = UserData::default();
+        let config_str =
+            toml::to_string(&default_config).map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
+        fs::write(&config_file, config_str)?;
+        set_permissions(&config_file, 0o600)?;
+    }
+    Ok(config_dir.join("config.toml"))
+}
+
+fn set_permissions(config_dir: &PathBuf, perms: u32) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let metadata = fs::metadata(&config_dir)?;
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(perms); // Sets directory to only be accessible by the owner
+        fs::set_permissions(&config_dir, permissions)?;
+    }
+    Ok(())
+}
+
+pub fn read_config() -> io::Result<UserData> {
+    let config_path = get_config_path()?;
+    let config_str = fs::read_to_string(config_path)?;
+    let config: UserData =
+        toml::from_str(&config_str).map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
+    Ok(config)
+}
+
+pub fn write_config(config: &Profile) -> io::Result<()> {
+    let config_path = get_config_path()?;
+    let config_str = toml::to_string(config).map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
+    fs::write(&config_path, config_str)?;
+    set_permissions(&config_path, 0o600)?;
+    Ok(())
+}

--- a/taritools/src/shopify/command_def.rs
+++ b/taritools/src/shopify/command_def.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use shopify_tools::ExchangeRate;
 use tpg_common::MicroTari;
@@ -81,13 +82,13 @@ pub enum RatesCommand {
     },
 }
 
-fn parse_exchange_rate(s: &str) -> Result<ExchangeRate, String> {
+fn parse_exchange_rate(s: &str) -> Result<ExchangeRate> {
     let parts: Vec<&str> = s.split('=').collect();
     if parts.len() != 2 {
-        return Err("Exchange rate must be in the form 'USD=10'".to_string());
+        return Err(anyhow!("Exchange rate must be in the form 'USD=10'"));
     }
     let base_currency = parts[0].to_string();
-    let rate = parts[1].parse::<i64>().map_err(|e| e.to_string())?;
+    let rate = parts[1].parse::<i64>()?;
     let rate = MicroTari::from_tari(rate);
     Ok(ExchangeRate::new(base_currency, rate))
 }

--- a/taritools/src/tari_payment_server/client.rs
+++ b/taritools/src/tari_payment_server/client.rs
@@ -1,0 +1,111 @@
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use log::info;
+use reqwest::{
+    header::{HeaderMap, HeaderValue},
+    Client,
+    StatusCode,
+};
+use tari_jwt::{
+    jwt_compact::{AlgorithmExt, Claims, Header},
+    Ristretto256,
+    Ristretto256SigningKey,
+};
+use tari_payment_engine::db_types::{LoginToken, UserAccount};
+use tari_payment_server::data_objects::{ExchangeRateResult, ExchangeRateUpdate};
+use tpg_common::MicroTari;
+
+use crate::profile_manager::Profile;
+
+pub struct PaymentServerClient {
+    client: Client,
+    profile: Profile,
+    access_token: String,
+}
+
+impl PaymentServerClient {
+    pub fn new(profile: Profile) -> Self {
+        let mut headers = HeaderMap::new();
+        headers.insert("Accept", HeaderValue::from_static("application/json"));
+
+        let client = Client::builder()
+            .user_agent("Tari Payment Server Client")
+            .default_headers(headers)
+            .build()
+            .expect("Failed to create reqwest client");
+        PaymentServerClient { client, profile, access_token: "".to_string() }
+    }
+
+    pub fn url(&self, path: &str) -> String {
+        format!("{}{}", self.profile.server, path)
+    }
+
+    pub async fn authenticate(&mut self) -> Result<()> {
+        println!("Authenticating with payment server");
+        let token = generate_auth_token(&self.profile)?;
+        let url = self.url("/auth");
+        let res = self.client.post(url).header("tpg_auth_token", token).send().await?;
+        if !res.status().is_success() {
+            let reason = res.text().await?;
+            return Err(anyhow::anyhow!("Failed to authenticate with payment server. {reason}"));
+        }
+        let token: String = res.text().await?;
+        info!("Authenticated with payment server. Access token: {}******", &token[..12]);
+        self.access_token = token;
+        Ok(())
+    }
+
+    pub async fn health(&self) -> Result<String> {
+        let url = self.url("/health");
+        let res = self.client.get(url).send().await?;
+        let response = res.text().await?;
+        Ok(response)
+    }
+
+    pub async fn my_account(&self) -> Result<UserAccount> {
+        let url = self.url("/api/account");
+        let res = self.client.get(url).header("tpg_access_token", self.access_token.clone()).send().await?;
+        match res.status() {
+            StatusCode::OK => Ok(res.json().await?),
+            StatusCode::NOT_FOUND => Err(anyhow!("No account exists for you yet")),
+            _ => {
+                let msg = res.text().await?;
+                Err(anyhow!("Error fetching account: {msg}"))
+            },
+        }
+    }
+
+    pub async fn fetch_exchange_rates(&self, currency: &str) -> Result<ExchangeRateResult> {
+        let url = self.url(format!("/api/exchange_rate/{currency}").as_str());
+        let res = self.client.get(url).header("tpg_access_token", self.access_token.clone()).send().await?;
+        match res.status() {
+            StatusCode::OK => Ok(res.json().await?),
+            code => {
+                let msg = res.text().await?;
+                Err(anyhow!("Error fetching exchange rate: {code}, {msg}."))
+            },
+        }
+    }
+
+    pub async fn set_exchange_rate(&self, currency: &str, price_in_tari: MicroTari) -> Result<()> {
+        let url = self.url("/api/exchange_rate");
+        let rate = ExchangeRateUpdate { currency: currency.to_string(), rate: price_in_tari.value() as u64 };
+        let res =
+            self.client.post(url).header("tpg_access_token", self.access_token.clone()).json(&rate).send().await?;
+        if !res.status().is_success() {
+            let msg = res.text().await?;
+            return Err(anyhow!("Error setting exchange rates: {msg}"));
+        }
+        Ok(())
+    }
+}
+
+fn generate_auth_token(profile: &Profile) -> Result<String> {
+    let nonce = Utc::now().timestamp() as u64;
+    let address = profile.address.clone().to_address();
+    let claims = LoginToken { address, nonce, desired_roles: profile.roles.clone() };
+    let claims = Claims::new(claims);
+    let header = Header::empty().with_token_type("JWT");
+    let token = Ristretto256.token(&header, &claims, &Ristretto256SigningKey(profile.secret_key.clone()))?;
+    Ok(token)
+}

--- a/taritools/src/tari_payment_server/mod.rs
+++ b/taritools/src/tari_payment_server/mod.rs
@@ -1,0 +1,1 @@
+pub mod client;

--- a/tpg_common/src/microtari.rs
+++ b/tpg_common/src/microtari.rs
@@ -70,8 +70,12 @@ impl TryFrom<u64> for MicroTari {
 
 impl Display for MicroTari {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let tari = self.0 as f64 / 1_000_000.0;
-        write!(f, "{tari:0.3}τ")
+        if self.0 < 10_000 {
+            return write!(f, "{}μτ", self.0);
+        } else {
+            let tari = self.0 as f64 / 1_000_000.0;
+            write!(f, "{tari:0.3}τ")
+        }
     }
 }
 


### PR DESCRIPTION
Provides the start of a Client for the Tari Payment Server API, and an interactive mode for taritools to carry out Admin functionality.

You can store `config.toml` in `~/.taritools` to store the profiles you want to use in the admin tool.

E.g.

```toml
name="SuperAdmin"
address="64500c6c16d80d4e53cdc58d7975ffb791593cd39d072d87e6b014396cb20d5186"
secret_key="secretxxxxxxxxxx"
roles=["super_admin"]
server="http://127.0.0.1:4444"

[[profiles]]
name="Admin"
address="f8fe60bf2ed7e540fd444374264d64c274f33b9190122118b17c195661c76d4ec9"
secret_key="secretxxxxxxx"
roles=["user","read_all","write"]
server="http://127.0.0.1:4444"

[[profiles]]
name="Normal user"
address="98f9516039bb669bbc3ad40fe795ffe8d34a22dc1995bfde95ce0efb38bf2525d8"
secret_key="secretxxxxxx"
roles=["user"]
server="http://127.0.0.1:4444"
```

Running `taritools` with no arguments provides a wizard-like interactive menu.

For now, you can authenticate, and set the exchange rate for USD-XTR which is successfully propagated to the Shopify store.

# Exchange rate change

The rate of "Tari per cent" was very confusing, so I've reverted it back to "Microtari per USD". The tests and conversion formulae have been updated accordingly