### PR TITLE
Console wallet integration

### DIFF
--- a/tari_payment_server/src/routes.rs
+++ b/tari_payment_server/src/routes.rs
@@ -712,12 +712,11 @@ where
     let PaymentNotification { payment, auth } = body.into_inner();
     let use_x_forwarded_for = config.use_x_forwarded_for;
     let use_forwarded = config.use_forwarded;
-    trace!("💻️ Extracting remote IP address. {req:?}. {:?}", req.connection_info());
+    // Log the payment
     let Some(peer_addr) = get_remote_ip(&req, use_x_forwarded_for, use_forwarded) else {
         warn!("💻️ Could not determine remote IP address for a wallet payment notification. The request is rejected");
         return HttpResponse::Unauthorized().finish();
     };
-    // Log the payment
     info!("💻️ New payment notification received from IP {peer_addr}.");
     info!("💻️ Payment: {}", serde_json::to_string(&payment).unwrap_or_else(|e| format!("{e}")));
     info!("💻️ Auth: {}", serde_json::to_string(&auth).unwrap_or_else(|e| format!("{e}")));
@@ -726,6 +725,7 @@ where
         warn!("💻️ Invalid wallet signature received from {peer_addr}. The request is rejected.");
         return HttpResponse::Unauthorized().finish();
     }
+    trace!("💻️ Extracting remote IP address. {req:?}. {:?}", req.connection_info());
     let auth_api = auth_api.as_ref();
     if let Err(e) = auth_api.authenticate_wallet(auth, &peer_addr, &payment).await {
         warn!("💻️ Unauthorized wallet signature received from {peer_addr}. Reason: {e}. The request is rejected.");

--- a/taritools/scripts/tps_notify.sh
+++ b/taritools/scripts/tps_notify.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Notify script for Tari Payment Server Hot wallet.
+
+# Install this script in `$HOME/.taritools/tps_notify.sh` and make it executable.
+
+# post to a webhook url
+BINPATH=${TARITOOLS_PATH:-$HOME/.cargo/bin}
+BIN=$BINPATH/taritools
+PROFILE="TPS Hot Wallet"
+
+register_received_payment() {
+  ${BIN} wallet --profile "$PROFILE" received --amount $2 --txid $3 --message "$4" --sender $5
+}
+
+# Log the event
+echo "$@" >> $HOME/.taritools/tps_notify.log
+
+if [ -z "${12}" ]; then
+  if [ "$1" == "received" ]; then
+    register_received_payment "$@"
+  elif [ "$1" == "confirmed" ]; then
+    register_confirmation "$@"
+  else
+    echo "Unhandled main event: $@"
+  fi
+else
+  echo "Unhandled short event: $@"
+# TODO - handle cancellations
+fi
+
+# Argument key:
+# For transaction received, mined(unconfirmed), and mined events:
+#  $1 = "received", "confirmation", or "mined"
+#  $2 = amount,
+#  $3 = tx_id
+#  $4 = message
+#  $5 = source address public key
+#  $6 = destination address public key
+#  $7 = status
+#  $8 = excess,
+#  $9 = public_nonce,
+# $10 = signature,
+# $11 = number of confirmations (if applicable, otherwise empty string)
+# $12 = direction
+
+# 2.
+# For transaction "sent" event, we only have the pending outbound transaction:
+# $1 = "sent"
+# $2 = amount,
+# $3 = tx_id
+# $4 = message
+# $5 = destination address public key
+# $6 = status,
+# $7 = direction,
+
+# 3.
+# For a transaction "cancelled" event, if it was still pending - it would have the same args as 2. (with $5 as source address public key if inbound).
+# If the cancelled tx was already out of pending state, the cancelled event will have the same args as 1.

--- a/taritools/scripts/tps_notify.sh
+++ b/taritools/scripts/tps_notify.sh
@@ -9,7 +9,11 @@ BIN=$BINPATH/taritools
 PROFILE="TPS Hot Wallet"
 
 register_received_payment() {
-  ${BIN} wallet --profile "$PROFILE" received --amount $2 --txid $3 --message "$4" --sender $5
+  ${BIN} wallet received --profile "$PROFILE" --amount $2 --txid $3 --message "$4" --sender $5
+}
+
+register_confirmation() {
+  ${BIN} wallet confirmation --profile "$PROFILE" --txid $3
 }
 
 # Log the event

--- a/taritools/src/main.rs
+++ b/taritools/src/main.rs
@@ -12,6 +12,7 @@ mod payments;
 mod shopify;
 
 mod tari_payment_server;
+mod wallet;
 
 use jwt_token::print_jwt_token;
 use log::*;
@@ -19,8 +20,9 @@ use tari_payment_engine::db_types::OrderId;
 
 use crate::{
     memo::print_memo_signature,
-    payments::{print_payment_auth, print_tx_confirm},
+    payments::{print_payment_auth, print_tx_confirm, WalletCommand},
     shopify::{handle_shopify_command, ShopifyCommand},
+    wallet::handle_wallet_command,
 };
 
 pub const APP_NAME: &str = env!("CARGO_PKG_NAME");
@@ -57,6 +59,8 @@ pub enum Command {
     TxConfirm(TxConfirmParams),
     #[command(subcommand)]
     Shopify(ShopifyCommand),
+    #[command(subcommand)]
+    Wallet(WalletCommand),
 }
 
 #[derive(Debug, Args)]
@@ -137,6 +141,7 @@ async fn run_command(cli: Arguments) {
         Command::PaymentAuth(params) => print_payment_auth(params),
         Command::TxConfirm(params) => print_tx_confirm(params),
         Command::Shopify(shopify_command) => handle_shopify_command(shopify_command).await,
+        Command::Wallet(wallet_command) => handle_wallet_command(wallet_command).await,
     }
 }
 

--- a/taritools/src/tari_payment_server/client.rs
+++ b/taritools/src/tari_payment_server/client.rs
@@ -12,7 +12,12 @@ use tari_jwt::{
     Ristretto256SigningKey,
 };
 use tari_payment_engine::db_types::{LoginToken, UserAccount};
-use tari_payment_server::data_objects::{ExchangeRateResult, ExchangeRateUpdate};
+use tari_payment_server::data_objects::{
+    ExchangeRateResult,
+    ExchangeRateUpdate,
+    PaymentNotification,
+    TransactionConfirmationNotification,
+};
 use tpg_common::MicroTari;
 
 use crate::profile_manager::Profile;
@@ -95,6 +100,28 @@ impl PaymentServerClient {
         if !res.status().is_success() {
             let msg = res.text().await?;
             return Err(anyhow!("Error setting exchange rates: {msg}"));
+        }
+        Ok(())
+    }
+
+    /// Send a payment notification to the payment server.
+    pub async fn payment_notification(&self, notification: PaymentNotification) -> Result<()> {
+        let url = self.url("/wallet/incoming_payment");
+        let res = self.client.post(url).json(&notification).send().await?;
+        if !res.status().is_success() {
+            let msg = res.text().await?;
+            return Err(anyhow!("Error sending payment notification: {msg}"));
+        }
+        Ok(())
+    }
+
+    /// Send a payment confirmation to the payment server.
+    pub async fn payment_confirmation(&self, confirmation: TransactionConfirmationNotification) -> Result<()> {
+        let url = self.url("/wallet/tx_confirmation");
+        let res = self.client.post(url).json(&confirmation).send().await?;
+        if !res.status().is_success() {
+            let msg = res.text().await?;
+            return Err(anyhow!("Error sending payment confirmation: {msg}"));
         }
         Ok(())
     }

--- a/taritools/src/wallet.rs
+++ b/taritools/src/wallet.rs
@@ -1,0 +1,59 @@
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use log::*;
+use tari_payment_engine::{db_types::NewPayment, helpers::WalletSignature};
+use tari_payment_server::data_objects::{
+    PaymentNotification,
+    TransactionConfirmation,
+    TransactionConfirmationNotification,
+};
+
+use crate::{
+    payments::{ConfirmationParams, ReceivedPaymentParams, WalletCommand},
+    profile_manager::{read_config, Profile},
+    tari_payment_server::client::PaymentServerClient,
+};
+
+pub async fn handle_wallet_command(command: WalletCommand) {
+    let result = match command {
+        WalletCommand::Received(params) => notify_server_about_payment(params).await,
+        WalletCommand::Confirmed(params) => notify_server_about_confirmation(params).await,
+    };
+    if let Err(e) = result {
+        error!("Wallet command failed: {e}");
+        eprintln!("Wallet command failed: {e}")
+    }
+}
+
+fn load_profile(name: &str) -> Result<Profile> {
+    let user_data = read_config()?;
+    let profile = user_data
+        .profiles
+        .iter()
+        .find(|p| p.name == name)
+        .cloned()
+        .ok_or_else(|| anyhow!("Profile \"{name}\" not found"))?;
+    Ok(profile)
+}
+
+fn new_nonce() -> i64 {
+    Utc::now().timestamp()
+}
+
+async fn notify_server_about_payment(params: ReceivedPaymentParams) -> Result<()> {
+    let profile = load_profile(&params.profile)?;
+    let client = PaymentServerClient::new(profile.clone());
+    let payment = NewPayment::from(params);
+    let auth = WalletSignature::create(profile.address, new_nonce(), &profile.secret_key, &payment)?;
+    let notification = PaymentNotification { payment, auth };
+    client.payment_notification(notification).await
+}
+
+async fn notify_server_about_confirmation(params: ConfirmationParams) -> Result<()> {
+    let profile = load_profile(&params.profile)?;
+    let txid = TransactionConfirmation { txid: params.txid };
+    let client = PaymentServerClient::new(profile.clone());
+    let auth = WalletSignature::create(profile.address, new_nonce(), &profile.secret_key, &txid)?;
+    let confirmation = TransactionConfirmationNotification { confirmation: txid, auth };
+    client.payment_confirmation(confirmation).await
+}


### PR DESCRIPTION
Adds the notification script for the Tari console wallet.
Includes documentation in INSTALLATION.md for how to set it up.

Console wallet integration comprises the following:

* `taritools/scripts/tps_notify.sh` - a bash script that is fired when
  the wallet receives or confirms payments. In turn, this calls
  `taritools`.
* New methods in the `PaymentServerClient` interface:
  payment_notification and payment_confirmation.
* New non-interactive CLI command, `wallet`, which has 2 subcommands,
  `received` and `confirmed` that are called by `tps_notify.sh` with the
  relevant transaction parameters. The commands will send a request to
  TPS with the payment into, and a signature that it generates using the
  stored profile.