### PR TITLE
feat: envar support for profiles

### DIFF
--- a/taritools/src/tari_payment_server/client.rs
+++ b/taritools/src/tari_payment_server/client.rs
@@ -156,6 +156,7 @@ fn generate_auth_token(profile: &Profile) -> Result<String> {
     let claims = LoginToken { address, nonce, desired_roles: profile.roles.clone() };
     let claims = Claims::new(claims);
     let header = Header::empty().with_token_type("JWT");
-    let token = Ristretto256.token(&header, &claims, &Ristretto256SigningKey(profile.secret_key.clone()))?;
+    let key = profile.secret_key().ok_or_else(|| anyhow!("Profile {} is missing a secret key", profile.name))?;
+    let token = Ristretto256.token(&header, &claims, &Ristretto256SigningKey(key))?;
     Ok(token)
 }

--- a/taritools/src/wallet.rs
+++ b/taritools/src/wallet.rs
@@ -44,7 +44,8 @@ async fn notify_server_about_payment(params: ReceivedPaymentParams) -> Result<()
     let profile = load_profile(&params.profile)?;
     let client = PaymentServerClient::new(profile.clone());
     let payment = NewPayment::from(params);
-    let auth = WalletSignature::create(profile.address, new_nonce(), &profile.secret_key, &payment)?;
+    let key = profile.secret_key().ok_or_else(|| anyhow!("Profile {} is missing a secret key", profile.name))?;
+    let auth = WalletSignature::create(profile.address, new_nonce(), &key, &payment)?;
     let notification = PaymentNotification { payment, auth };
     client.payment_notification(notification).await
 }
@@ -53,7 +54,8 @@ async fn notify_server_about_confirmation(params: ConfirmationParams) -> Result<
     let profile = load_profile(&params.profile)?;
     let txid = TransactionConfirmation { txid: params.txid };
     let client = PaymentServerClient::new(profile.clone());
-    let auth = WalletSignature::create(profile.address, new_nonce(), &profile.secret_key, &txid)?;
+    let key = profile.secret_key().ok_or_else(|| anyhow!("Profile {} is missing a secret key", profile.name))?;
+    let auth = WalletSignature::create(profile.address, new_nonce(), &key, &txid)?;
     let confirmation = TransactionConfirmationNotification { confirmation: txid, auth };
     client.payment_confirmation(confirmation).await
 }


### PR DESCRIPTION
Secret keys for profiles can now be specified in ENVARs instead of storing them in plain text on disk.

e.g.:

```toml
[[profiles]]
name="Alice"
address="b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d"
secret_key="thiskeyisstoredondiskwhichmaybeaproblem"
roles=["user"]
server="http://127.0.0.1:4444"

[[profiles]]
name="Test Key Env"
address = "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d"
roles=["user"]
server="http://127.0.0.1:4444"
secret_key_envar="TEST_KEY_SECRET"
```

The `Test Key Env` profile will read the secret key in from whatever is stored in the `TEST_KEY_SECRET` environment variable. That key **must** be the secret key corresponding to the address given in the profile.