### PR TITLE
feat: cli commands for orders

### DIFF
--- a/tari_payment_engine/src/db_types.rs
+++ b/tari_payment_engine/src/db_types.rs
@@ -84,6 +84,18 @@ impl From<TariAddress> for SerializedTariAddress {
     }
 }
 
+impl From<&TariAddress> for SerializedTariAddress {
+    fn from(value: &TariAddress) -> Self {
+        Self(value.clone())
+    }
+}
+
+impl Display for SerializedTariAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_hex())
+    }
+}
+
 impl<'r, DB: Database> Decode<'r, DB> for SerializedTariAddress
 // we want to delegate some of the work to string
 // decoding so let's make sure strings are supported by

--- a/tari_payment_engine/src/tpe_api/accounts_api.rs
+++ b/tari_payment_engine/src/tpe_api/accounts_api.rs
@@ -47,7 +47,7 @@ where B: AccountManagement
     /// Fetches all orders associated with the given Tari address, and wraps them in an `OrderResult`, which includes
     /// the metadata of the address and the sum of the orders' values.
     pub async fn orders_for_address(&self, address: &TariAddress) -> Result<Option<OrderResult>, AccountApiError> {
-        let mut result = OrderResult { address: address.clone(), total_orders: 0.into(), orders: vec![] };
+        let mut result = OrderResult { address: address.into(), total_orders: 0.into(), orders: vec![] };
         match self.account_by_address(address).await {
             Ok(Some(acc)) => {
                 result.total_orders = acc.total_orders;

--- a/tari_payment_engine/src/tpe_api/order_objects.rs
+++ b/tari_payment_engine/src/tpe_api/order_objects.rs
@@ -6,15 +6,14 @@ use tari_common_types::tari_address::TariAddress;
 use tpg_common::MicroTari;
 
 use crate::{
-    db_types::{Order, OrderId, OrderStatusType},
+    db_types::{Order, OrderId, OrderStatusType, SerializedTariAddress},
     helpers,
     traits::AccountApiError,
 };
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct OrderResult {
-    #[serde(serialize_with = "address_to_hex")]
-    pub address: TariAddress,
+    pub address: SerializedTariAddress,
     pub total_orders: MicroTari,
     pub orders: Vec<Order>,
 }

--- a/tari_payment_server/src/routes.rs
+++ b/tari_payment_server/src/routes.rs
@@ -371,7 +371,8 @@ pub async fn unfulfilled_orders<B: AccountManagement>(
         debug!("💻️ Could not fetch unfulfilled orders. {e}");
         ServerError::BackendError(e.to_string())
     })?;
-    let result = OrderResult { address, total_orders: orders.iter().map(|o| o.total_price).sum(), orders };
+    let result =
+        OrderResult { address: address.into(), total_orders: orders.iter().map(|o| o.total_price).sum(), orders };
     Ok(HttpResponse::Ok().json(result))
 }
 

--- a/taritools/src/interactive/menus.rs
+++ b/taritools/src/interactive/menus.rs
@@ -6,7 +6,7 @@ pub type Menu = (&'static str, &'static [&'static str]);
 
 pub const TOP_MENU: [&str; 5] = ["Admin Menu", "User Menu", "Server health", "Logout", "Exit"];
 pub const ADMIN_MENU: [&str; 5] = ["Fetch Tari price", "Set Tari price", "Logout", "Back", "Exit"];
-pub const USER_MENU: [&str; 4] = ["My Account", "Logout", "Back", "Exit"];
+pub const USER_MENU: [&str; 6] = ["My Account", "Logout", "Back", "Exit", "My Orders", "My Open Orders"];
 
 pub fn top_menu() -> &'static Menu {
     &("Main", &TOP_MENU)


### PR DESCRIPTION
Adds CLI commands for "my orders" and "my open orders" as well as the corresponding Client API library calls.