### PR TITLE
feat: full account history

### DIFF
--- a/tari_payment_engine/src/tpe_api/account_objects.rs
+++ b/tari_payment_engine/src/tpe_api/account_objects.rs
@@ -6,11 +6,11 @@ use crate::db_types::{Order, Payment, SerializedTariAddress, UserAccount};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FullAccount {
-    account: UserAccount,
-    addresses: Vec<AccountAddress>,
-    customer_ids: Vec<CustomerId>,
-    orders: Vec<Order>,
-    payments: Vec<Payment>,
+    pub account: UserAccount,
+    pub addresses: Vec<AccountAddress>,
+    pub customer_ids: Vec<CustomerId>,
+    pub orders: Vec<Order>,
+    pub payments: Vec<Payment>,
 }
 
 impl FullAccount {

--- a/taritools/src/interactive/menus.rs
+++ b/taritools/src/interactive/menus.rs
@@ -16,7 +16,8 @@ pub const ADMIN_MENU: [&str; 9] = [
     "Payments for Address",
     "Exit",
 ];
-pub const USER_MENU: [&str; 7] = ["My Account", "Logout", "Back", "Exit", "My Orders", "My Open Orders", "My Payments"];
+pub const USER_MENU: [&str; 8] =
+    ["My Account", "Logout", "Back", "Exit", "My Orders", "My Open Orders", "My Payments", "Account History"];
 
 pub fn top_menu() -> &'static Menu {
     &("Main", &TOP_MENU)

--- a/taritools/src/tari_payment_server/client.rs
+++ b/taritools/src/tari_payment_server/client.rs
@@ -18,7 +18,7 @@ use tari_jwt::{
 use tari_payment_engine::{
     db_types::{CreditNote, LoginToken, Order, Role, UserAccount},
     order_objects::OrderResult,
-    tpe_api::payment_objects::PaymentsResult,
+    tpe_api::{account_objects::FullAccount, payment_objects::PaymentsResult},
 };
 use tari_payment_server::data_objects::{
     ExchangeRateResult,
@@ -148,6 +148,16 @@ impl PaymentServerClient {
 
     pub async fn my_payments(&self) -> Result<PaymentsResult> {
         self.auth_get_request("/api/payments").await
+    }
+
+    /// Returns the Account History (or full account) for the authenticated address (anchor address).
+    ///
+    /// **Note**: This could return orders and payments that are not present in [`my_orders`], or [`my_payments']
+    /// respectively, since these methods only provide data directly linked to the anchor address, whereas `my_history`
+    /// does a reverse link search to find _all_ addresses attached to the account before querying for orders and
+    /// payments.
+    pub async fn my_history(&self) -> Result<FullAccount> {
+        self.auth_get_request("/api/history").await
     }
 
     async fn auth_get_request<T: DeserializeOwned>(&self, path: &str) -> Result<T> {


### PR DESCRIPTION
* Adds User CLI command, "My Account History", which provides a consolidated view of all accounts, addresses, orders and payments linked to the account attached to the authenticated address.

  Note that this could return orders that are not present in "My Orders", since the latter only provides data directly linked to the authenticated address, whereas "My History" does a reverse link search to find all addresses attached to the account.

* Adds `my_history` method to API client.

* Reformats how orders are printed into markdown.