### PR TITLE
feat: account history for admins

### DIFF
--- a/taritools/src/interactive/menus.rs
+++ b/taritools/src/interactive/menus.rs
@@ -5,7 +5,7 @@
 pub type Menu = (&'static str, &'static [&'static str]);
 
 pub const TOP_MENU: [&str; 5] = ["Admin Menu", "User Menu", "Server health", "Logout", "Exit"];
-pub const ADMIN_MENU: [&str; 9] = [
+pub const ADMIN_MENU: [&str; 11] = [
     "Fetch Tari price",
     "Set Tari price",
     "Logout",
@@ -14,6 +14,8 @@ pub const ADMIN_MENU: [&str; 9] = [
     "Order by Id",
     "Orders for Address",
     "Payments for Address",
+    "History for Address",
+    "History for Account Id",
     "Exit",
 ];
 pub const USER_MENU: [&str; 8] =

--- a/taritools/src/interactive/mod.rs
+++ b/taritools/src/interactive/mod.rs
@@ -108,6 +108,8 @@ impl InteractiveApp {
                 "Order by Id" => handle_response(self.order_by_id().await),
                 "Orders for Address" => handle_response(self.orders_for_address().await),
                 "Payments for Address" => handle_response(self.payments_for_address().await),
+                "History for Address" => handle_response(self.history_for_address().await),
+                "History for Account Id" => handle_response(self.history_for_id().await),
                 "Logout" => self.logout(),
                 "Back" => self.pop_menu(),
                 "Exit" => break,
@@ -178,6 +180,22 @@ impl InteractiveApp {
         let _unused = self.login().await?;
         let client = self.client.as_ref().unwrap();
         let history = client.my_history().await?;
+        format_full_account(history)
+    }
+
+    async fn history_for_address(&mut self) -> Result<String> {
+        let _unused = self.login().await;
+        let address = self.select_address().await?;
+        let client = self.client.as_ref().unwrap();
+        let history = client.history_for_address(&address).await?;
+        format_full_account(history)
+    }
+
+    async fn history_for_id(&mut self) -> Result<String> {
+        let _unused = self.login().await;
+        let client = self.client.as_ref().unwrap();
+        let account_id = dialoguer::Input::<i64>::new().with_prompt("Enter account id (NOT customer id)").interact()?;
+        let history = client.history_for_id(account_id).await?;
         format_full_account(history)
     }
 

--- a/taritools/src/tari_payment_server/client.rs
+++ b/taritools/src/tari_payment_server/client.rs
@@ -160,6 +160,14 @@ impl PaymentServerClient {
         self.auth_get_request("/api/history").await
     }
 
+    pub async fn history_for_address(&self, address: &TariAddress) -> Result<FullAccount> {
+        self.auth_get_request(&format!("/api/history/address/{}", address.to_hex())).await
+    }
+
+    pub async fn history_for_id(&self, account_id: i64) -> Result<FullAccount> {
+        self.auth_get_request(&format!("/api/history/id/{account_id}")).await
+    }
+
     async fn auth_get_request<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
         let url = self.url(path);
         let res = self.client.get(url).header("tpg_access_token", self.access_token.clone()).send().await?;


### PR DESCRIPTION
* Adds CLI commands to retrieve account history of any account, by Tari address, or account id.
* Adds client API methods for same.