### PR TITLE
feat: order management

### DIFF
--- a/tari_payment_engine/src/sqlite/sqlite_impl.rs
+++ b/tari_payment_engine/src/sqlite/sqlite_impl.rs
@@ -383,7 +383,7 @@ impl PaymentGatewayDatabase for SqliteDatabase {
         let order = orders::fetch_order_by_order_id(order_id, &mut tx)
             .await?
             .ok_or_else(|| AccountApiError::OrderDoesNotExist(order_id.clone()))?;
-        if order.status != OrderStatusType::New {
+        if !&[OrderStatusType::New, OrderStatusType::Unclaimed].contains(&order.status) {
             error!("🗃️ Order {} is not in 'New' status. Cannot call cancel_or_expire_order", order.id);
             return Err(PaymentGatewayError::OrderModificationForbidden);
         }

--- a/taritools/src/interactive/formatting.rs
+++ b/taritools/src/interactive/formatting.rs
@@ -105,7 +105,17 @@ pub fn format_orders(orders: &[Order]) -> String {
         return "No open orders".to_string();
     }
     let mut table = Table::new();
-    table.set_titles(row!["ID", "Amount", "Status", "Original price", "Currency", "Memo", "Created At", "Updated At"]);
+    table.set_titles(row![
+        "ID",
+        "Order id",
+        "Amount",
+        "Status",
+        "Original price",
+        "Currency",
+        "Memo",
+        "Created At",
+        "Updated At"
+    ]);
     let mut memos = Vec::new();
     orders.iter().for_each(|order| {
         let memo_note = match order.memo {
@@ -117,6 +127,7 @@ pub fn format_orders(orders: &[Order]) -> String {
         };
         table.add_row(row![
             order.id,
+            order.order_id,
             order.total_price.to_string(),
             order.status.to_string(),
             order.original_price.as_deref().unwrap_or_default(),

--- a/taritools/src/interactive/menus.rs
+++ b/taritools/src/interactive/menus.rs
@@ -5,7 +5,10 @@
 pub type Menu = (&'static str, &'static [&'static str]);
 
 pub const TOP_MENU: [&str; 5] = ["Admin Menu", "User Menu", "Server health", "Logout", "Exit"];
-pub const ADMIN_MENU: [&str; 11] = [
+pub const ADMIN_MENU: [&str; 14] = [
+    "Cancel Order",
+    "Mark order as Paid",
+    "Reset Order",
     "Fetch Tari price",
     "Set Tari price",
     "Logout",


### PR DESCRIPTION
* Adds client api method for resetting order.
* Adds client api method for fulfilling order.
* Adds CLI command for cancelling order.
* Adds CLI command for fulfilling order.
* Adds CLI command for resetting order.

Removes constraint that the annulled_order hook is only called on cancellations. The hook is *not* called when cancelling orders from Shopify admin panel, so we don't end up in a loop.

This allow enables cancellation of orders from the CLI