### PR TITLE
feat: wallet management endpoints

### DIFF
--- a/e2e/tests/features/wallet_management.feature
+++ b/e2e/tests/features/wallet_management.feature
@@ -1,0 +1,159 @@
+@wallet_management
+Feature: Wallet Management
+  Background:
+    Given a blank slate
+    Given some role assignments
+    Given an authorized wallet with secret df158b8389c68aac01a91276b742d2527f951d3c7289e4ccdecfa0672947270e
+    """
+      {
+        "address": "c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "ip_address": "192.168.1.100"
+      }
+    """
+
+  Scenario: Unauthenticated user can list authorized addresses
+    When User GETs to "/wallet/send_to" with body
+    Then I receive a 200 OK response
+    And I receive a partial JSON response:
+    """
+    ["c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495"]
+    """
+
+  Scenario: SuperAdmin can add an authorized wallet
+    Given a super-admin user (Super)
+    When Super authenticates with nonce = 1
+    When Super POSTs to "/api/wallets" with body
+    """
+    {
+      "address": "7a83ef47b358bead8f2e595814146784014002a6aa124c9b31134e489d27617309",
+      "ip_address": "100.50.60.70",
+      "initial_nonce": 1
+    }
+    """
+    Then I receive a 200 OK response
+
+  Scenario: Unauthenticated user cannot add an authorized wallet
+    When User POSTs to "/api/wallets" with body
+    """
+    {
+      "address": "7a83ef47b358bead8f2e595814146784014002a6aa124c9b31134e489d27617309",
+      "ip_address": "100.50.60.70",
+      "initial_nonce": 1
+    }
+    """
+    Then I receive a 401 Unauthenticated response with the message 'An error occurred, no cookie containing a jwt was found in the request.'
+
+  Scenario: Normal user cannot add an authorized wallet
+    When Alice authenticates with nonce = 1 and roles = "user"
+    When Alice POSTs to "/api/wallets" with body
+    """
+    {
+      "address": "7a83ef47b358bead8f2e595814146784014002a6aa124c9b31134e489d27617309",
+      "ip_address": "100.50.60.70",
+      "initial_nonce": 1
+    }
+    """
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+  Scenario: ReadAll admin cannot add an authorized wallet
+    When Admin authenticates with nonce = 1 and roles = "read_all"
+    When Admin POSTs to "/api/wallets" with body
+    """
+    {
+      "address": "7a83ef47b358bead8f2e595814146784014002a6aa124c9b31134e489d27617309",
+      "ip_address": "100.50.60.70",
+      "initial_nonce": 1
+    }
+    """
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+  Scenario: Write admin cannot add an authorized wallet
+    When Admin authenticates with nonce = 1 and roles = "write"
+    When Admin POSTs to "/api/wallets" with body
+    """
+    {
+      "address": "7a83ef47b358bead8f2e595814146784014002a6aa124c9b31134e489d27617309",
+      "ip_address": "100.50.60.70",
+      "initial_nonce": 1
+    }
+    """
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+  Scenario: SuperAdmin user can list authorized wallets
+    Given a super-admin user (Super)
+    When Super authenticates with nonce = 1
+    When Super GETs to "/api/wallets" with body
+    Then I receive a 200 OK response
+    And I receive a partial JSON response:
+    """
+    [
+      {
+        "address": "c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "ip_address": "192.168.1.100",
+        "last_nonce": 0
+      }
+    ]
+    """
+
+  Scenario: Unauthenticated user cannot list authorized wallets
+    When User GETs to "/api/wallets" with body
+    Then I receive a 401 Unauthenticated response with the message 'An error occurred, no cookie containing a jwt was found in the request.'
+
+  Scenario: Normal user cannot list authorized wallets
+    When Alice authenticates with nonce = 1 and roles = "user"
+    When Alice GETs to "/api/wallets" with body
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+  Scenario: ReadAll user can list authorized wallets
+    When Admin authenticates with nonce = 1 and roles = "read_all"
+    When Admin GETs to "/api/wallets" with body
+    Then I receive a 200 OK response
+    And I receive a partial JSON response:
+    """
+    [
+      {
+        "address": "c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "ip_address": "192.168.1.100",
+        "last_nonce": 0
+      }
+    ]
+    """
+
+  Scenario: SuperAdmin user can remove an authorized addresses
+    Given a super-admin user (Super)
+    When Super authenticates with nonce = 1
+    When Super DELETEs to "/api/wallets/c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495" with body
+    Then I receive a 200 OK response
+    When User GETs to "/wallet/send_to" with body
+    Then I receive a 200 OK response
+    And I receive a partial JSON response:
+    """
+    []
+    """
+
+  Scenario: Unauthenticated user cannot remove an authorized addresses
+    When User DELETEs to "/api/wallets/c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495" with body
+    Then I receive a 401 Unauthenticated response with the message 'An error occurred, no cookie containing a jwt was found in the request.'
+
+  Scenario: Normal user cannot remove an authorized addresses
+    When Alice authenticates with nonce = 1 and roles = "user"
+    When Alice DELETEs to "/api/wallets/c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495" with body
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+  Scenario: ReadAll admin cannot remove an authorized addresses
+    When Admin authenticates with nonce = 1 and roles = "read_all"
+    When Admin DELETEs to "/api/wallets/c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495" with body
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+  Scenario: Write admin cannot remove an authorized addresses
+    When Admin authenticates with nonce = 1 and roles = "write"
+    When Admin DELETEs to "/api/wallets/c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495" with body
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+
+
+
+
+
+
+

--- a/tari_payment_engine/src/sqlite/sqlite_impl.rs
+++ b/tari_payment_engine/src/sqlite/sqlite_impl.rs
@@ -814,12 +814,18 @@ impl WalletManagement for SqliteDatabase {
         wallet_auth::register_wallet(wallet, &mut conn).await
     }
 
-    async fn deregister_wallet(&self, _wallet_address: &TariAddress) -> Result<WalletInfo, WalletManagementError> {
-        todo!()
+    async fn deregister_wallet(&self, _wallet_address: &TariAddress) -> Result<(), WalletManagementError> {
+        let mut conn = self.pool.acquire().await?;
+        wallet_auth::deregister_wallet(_wallet_address, &mut conn).await
     }
 
     async fn update_wallet_info(&self, _wallet: UpdateWalletInfo) -> Result<(), WalletManagementError> {
         todo!()
+    }
+
+    async fn fetch_authorized_wallets(&self) -> Result<Vec<WalletInfo>, WalletManagementError> {
+        let mut conn = self.pool.acquire().await?;
+        wallet_auth::fetch_authorized_wallets(&mut conn).await
     }
 }
 

--- a/tari_payment_engine/src/tpe_api/wallet_api.rs
+++ b/tari_payment_engine/src/tpe_api/wallet_api.rs
@@ -6,7 +6,7 @@ use tari_common_types::tari_address::TariAddress;
 
 use crate::{
     helpers::WalletSignature,
-    traits::{WalletAuth, WalletAuthApiError, WalletInfo},
+    traits::{NewWalletInfo, WalletAuth, WalletAuthApiError, WalletInfo, WalletManagement, WalletManagementError},
 };
 
 #[derive(Clone)]
@@ -72,5 +72,32 @@ where B: WalletAuth
         }
         self.update_wallet_nonce(address, sig.nonce).await?;
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct WalletManagementApi<B> {
+    db: B,
+}
+
+impl<B> WalletManagementApi<B> {
+    pub fn new(db: B) -> Self {
+        Self { db }
+    }
+}
+
+impl<B> WalletManagementApi<B>
+where B: WalletManagement
+{
+    pub async fn fetch_authorized_wallets(&self) -> Result<Vec<WalletInfo>, WalletManagementError> {
+        self.db.fetch_authorized_wallets().await
+    }
+
+    pub async fn register_wallet(&self, new_wallet_info: NewWalletInfo) -> Result<(), WalletManagementError> {
+        self.db.register_wallet(new_wallet_info).await
+    }
+
+    pub async fn deregister_wallet(&self, address: &TariAddress) -> Result<(), WalletManagementError> {
+        self.db.deregister_wallet(address).await
     }
 }

--- a/tari_payment_engine/src/traits/wallet_management.rs
+++ b/tari_payment_engine/src/traits/wallet_management.rs
@@ -17,10 +17,13 @@ pub trait WalletManagement {
     async fn register_wallet(&self, wallet: NewWalletInfo) -> Result<(), WalletManagementError>;
 
     /// Removes the wallet with the given address from the wallet auth table in the database.
-    async fn deregister_wallet(&self, wallet_address: &TariAddress) -> Result<WalletInfo, WalletManagementError>;
+    async fn deregister_wallet(&self, wallet_address: &TariAddress) -> Result<(), WalletManagementError>;
 
     /// Updates the wallet with the given address in the wallet auth table in the database.
     async fn update_wallet_info(&self, wallet: UpdateWalletInfo) -> Result<(), WalletManagementError>;
+
+    /// Retrieves all authorized wallets from the wallet auth table in the database.
+    async fn fetch_authorized_wallets(&self) -> Result<Vec<WalletInfo>, WalletManagementError>;
 }
 
 #[derive(Debug, Clone, Error)]


### PR DESCRIPTION
* Adds `GET wallet/send_to` which lists valid payment addresses for the server
* Adds `GET api/wallets` which lists additional wallet information for admins
* Adds `POST api/wallet` which allows SuperAdmins (only) to add a new authorized wallet address and whitelisted IP address
* Adds `DELETE api/wallet/{address}` which allows SuperAdmins (only) to remove a wallet address from the authorised set.

Adds 15 new cucumber tests to test these new endpoints.