### PR TITLE
docs: update docs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,8 +29,8 @@ TPG_UNPAID_ORDER_TIMEOUT=48
 DATABASE_URL=sqlite://data/tari_store.db
 DATABASE_TYPE=sqlite
 
-# Set this to take the safety belt off and skip the preflight checks when starting the server.
-# TPG_SKIP_PREFLIGHT=Yes
+# Set this to "Yes" take the safety belt off and skip the preflight checks when starting the server.
+TPG_SKIP_PREFLIGHT=No
 
 # Set this to the default authorized wallet to use for the "Send to" field in QR codes
 TPG_PAYMENT_WALLET_ADDRESS=0859fb3d6696579310c220d204cb21437d6658d0a05af1c8cd54fffd8725344352

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,10 +77,9 @@ jobs:
           cp README.md INSTALLATION.md SHOPIFY_INTEGRATION.md release_assets/
           cp .env.sample release_assets/
           cp -r taritools/scripts release_assets/
-          cp $(which sqlx) release_assets/
-          chmod +x release_assets/sqlx
           cp target/ubuntu/release/taritools release_assets/
           cp target/ubuntu/release/tari_payment_server release_assets/
+          cp -r tari_payment_engine/src/sqlite/migrations release_assets/
 
       - name: "Upload release assets: Tari Payment Server (Ubuntu)"
         if: steps.ubuntu_build.outcome == 'success'
@@ -97,9 +96,9 @@ jobs:
           cp README.md INSTALLATION.md SHOPIFY_INTEGRATION.md release_assets/
           cp .env.sample release_assets/
           cp -r taritools/scripts release_assets/
-          # Figure out how to get sqlx on windows
           cp target/windows/release/taritools release_assets/
           cp target/windows/release/tari_payment_server release_assets/
+          cp -r tari_payment_engine/src/sqlite/migrations release_assets/
 
       - name: "Upload release assets: Tari Payment Server (Windows)"
         if: steps.win_build.outcome == 'success'
@@ -181,9 +180,9 @@ jobs:
           cp README.md INSTALLATION.md SHOPIFY_INTEGRATION.md release_assets/
           cp .env.sample release_assets/
           cp -r taritools/scripts release_assets/
-          cp $(which sqlx) release_assets/
           cp target/release/taritools release_assets/
           cp target/release/tari_payment_server release_assets/
+          cp -r tari_payment_engine/src/sqlite/migrations release_assets/
 
       - name: "Upload release assets: Tari Payment Server (MacOs)"
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,6 +4567,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shopify_tools",
+ "sqlx",
  "tari-jwt",
  "tari_common 1.0.0-rc.5",
  "tari_common_types 1.0.0-rc.5",

--- a/tari_payment_engine/src/sqlite/db/mod.rs
+++ b/tari_payment_engine/src/sqlite/db/mod.rs
@@ -21,8 +21,8 @@ pub mod wallet_auth;
 const SQLITE_DB_URL: &str = "sqlite://data/tari_store.db";
 
 pub fn db_url() -> String {
-    let result = env::var("SPG_DATABASE_URL").unwrap_or_else(|_| {
-        info!("SPG_DATABASE_URL is not set. Using the default.");
+    let result = env::var("TPG_DATABASE_URL").unwrap_or_else(|_| {
+        info!("TPG_DATABASE_URL is not set. Using the default.");
         SQLITE_DB_URL.to_string()
     });
     info!("Using database URL: {result}");

--- a/tari_payment_server/src/cli-help.txt
+++ b/tari_payment_server/src/cli-help.txt
@@ -13,8 +13,47 @@ The server is run without command line parameters. But the following environment
 are read to configure the server:
 
 ENVIRONMENT VARIABLES:
+----------------------
 
-SPG_HOST: The host name to listen on. Defaults to 127.0.0.1
-SPG_PORT: The port to listen on. Defaults to 8360
-SPG_SHOPIFY_API_KEY: The Shopify API key to use. Defaults to an empty string
-RUST_LOG: The log level to use. Defaults to info
+- `TPG_HOST`: This variable is used to set the host of the server. If not set, the default value is `127.0.0.1`.
+- `TPG_PORT`: This variable is used to set the port on which the server will run. If not set or if the provided value is not a valid port, the default value is `8360`.
+- `RUST_LOG`: Sets the verbosity of the log messages. A good default that provides plenty of useful information without generating information overload is:
+  RUST_LOG=warn,access_log=info,tari_payment_server=info,tari_payment_engine=info,tpg_common=info,e2e_tests=info,sqlx=warn,shopify_tools=info
+  At the minimum, set `access_log=INFO` to use the access log middleware to log all incoming requests.
+- `TPG_DATABASE_URL`: This variable is used to set the URL for the TPG database. If not set, an error message will be logged, and the value will be set to an empty string. It's of the form `sqlite://<path to database file>` or `postgres://<username>:<password>@<host>/<database>`.
+
+- `TPG_PAYMENT_WALLET_ADDRESS`: The public key of the wallet that will receive payments. This key must be present in the Authorized Wallet list in the database. (Note: This envar will be deprecated in future)
+
+Forwarding remote IP addresses:
+-------------------------------
+
+To use the `X-Forwarded-For` or `Forwarded` headers to get the remote IP address, set the following environment variables:
+- `TPG_USE_X_FORWARDED_FOR=1`
+- `TPG_USE_FORWARDED=1`
+
+Unless you're behind a reverse proxy, you should not need to set these variables.
+
+Order expiry times:
+-------------------
+
+During the normal course of events, there will be many abandoned orders accumulating in the system. To prevent this becoming a long-term drain of performance and resources, unclaimed and unpaid orders are set to expire after a certain period.
+
+Unclaimed orders, which are a minor vector for a Sybil or DoS attack, should be set to expire after a relatively short period. The default is 2 hours.
+
+`TPG_UNCLAIMED_ORDER_TIMEOUT=2` # Expiry time for new, unclaimed orders, in hours
+
+Orders that have been claimed and are therefore associated with a wallet address have a longer default timeout of 48 hours.
+
+`TPG_UNPAID_ORDER_TIMEOUT=48` # Expiry time for unpaid orders, in hours
+
+Shopify environment variables:
+------------------------------
+
+See SHOPIFY_INTEGRATION.md for more information on how to set these environment variables.
+
+* `TPG_SHOPIFY_SHOP`
+* `TPG_SHOPIFY_API_VERSION`
+* `TPG_SHOPIFY_ADMIN_ACCESS_TOKEN`
+* `TPG_SHOPIFY_API_SECRET`
+
+

--- a/tari_payment_server/src/cli.rs
+++ b/tari_payment_server/src/cli.rs
@@ -1,12 +1,14 @@
 use std::{env, env::VarError};
 
 /// There's no real CLI for the server, so just do quick 'n dirty
-pub fn handle_command_line_args() {
-    if env::args().count() > 1 {
+pub fn handle_command_line_args() -> bool {
+    let has_cli_args = env::args().count() > 1;
+    if has_cli_args {
         // We don't expect any CLI args, so always print the help
         display_readme();
         display_envs();
     }
+    has_cli_args
 }
 
 fn display_readme() {
@@ -16,9 +18,24 @@ fn display_readme() {
 
 fn display_envs() {
     // Be explicit about which envars to print, so as to avoid accidentally exposing secrets
-    const DISPLAY_ENVS: [&str; 1] = ["RUST_LOG"];
+    const DISPLAY_ENVS: [&str; 14] = [
+        "RUST_LOG",
+        "TPG_SHOPIFY_SHOP",
+        "TPG_SHOPIFY_API_VERSION",
+        "TPG_SHOPIFY_HMAC_CHECKS",
+        "TPG_HOST",
+        "TPG_PORT",
+        "TPG_DATABASE_URL",
+        "TPG_SHOPIFY_IP_WHITELIST",
+        "TPG_USE_X_FORWARDED_FOR",
+        "TPG_USE_FORWARDED",
+        "TPG_UNCLAIMED_ORDER_TIMEOUT",
+        "TPG_UNPAID_ORDER_TIMEOUT",
+        "TPG_SKIP_PREFLIGHT",
+        "TPG_PAYMENT_WALLET_ADDRESS",
+    ];
 
-    println!("Current environment values:");
+    println!("Current environment values (EXCLUDING variables that contain secrets):");
     DISPLAY_ENVS.iter().for_each(|&name| {
         let val = match env::var(name) {
             Ok(s) => s,

--- a/tari_payment_server/src/main.rs
+++ b/tari_payment_server/src/main.rs
@@ -13,7 +13,9 @@ use tari_payment_server::{
 async fn main() {
     dotenv().ok();
     env_logger::init();
-    handle_command_line_args();
+    if handle_command_line_args() {
+        return;
+    }
     let config = ServerConfig::from_env_or_default();
     if !preflight_check(&config) {
         eprintln!("🚀️ Preflight check failed. Exiting. Check the logs for details.");

--- a/taritools/Cargo.toml
+++ b/taritools/Cargo.toml
@@ -24,6 +24,7 @@ rand = "0.8.4"
 reqwest = { version = "0.12.2", features = ["json"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.117"
+sqlx = { version = "0.7.3", features = ["runtime-tokio", "chrono"] }
 tari_crypto = "0.20.0"
 tari_common = "1.0.0-rc.5"
 tari_common_types = "1.0.0-rc.5"

--- a/taritools/src/main.rs
+++ b/taritools/src/main.rs
@@ -9,6 +9,7 @@ mod profile_manager;
 
 mod memo;
 mod payments;
+mod setup;
 mod shopify;
 
 mod tari_payment_server;
@@ -22,6 +23,7 @@ use crate::{
     interactive::InteractiveApp,
     memo::print_memo_signature,
     payments::{print_payment_auth, print_tx_confirm, WalletCommand},
+    setup::{handle_setup_command, SetupCommand},
     shopify::{handle_shopify_command, ShopifyCommand},
     wallet::handle_wallet_command,
 };
@@ -96,6 +98,9 @@ pub enum Command {
     /// See `tps_notify.sh`.
     #[command(subcommand)]
     Wallet(WalletCommand),
+    #[command(subcommand)]
+    /// Commands for helping in setting up the Tari Payment Server.
+    Setup(SetupCommand),
 }
 
 #[derive(Debug, Args)]
@@ -180,6 +185,7 @@ async fn run_command(cli: Arguments) {
         Command::TxConfirm(params) => print_tx_confirm(params),
         Command::Shopify(shopify_command) => handle_shopify_command(shopify_command).await,
         Command::Wallet(wallet_command) => handle_wallet_command(wallet_command).await,
+        Command::Setup(setup_command) => handle_setup_command(setup_command).await,
     }
 }
 

--- a/taritools/src/setup.rs
+++ b/taritools/src/setup.rs
@@ -1,0 +1,109 @@
+use std::path::Path;
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use sqlx::{
+    migrate::{MigrateDatabase, Migrator},
+    Sqlite,
+};
+use tari_payment_engine::{
+    db_types::{Role, SerializedTariAddress},
+    sqlite::db::db_url,
+    traits::AuthManagement,
+    SqliteDatabase,
+};
+
+/// Setup commands work locally to set up Tari Payment Server. These commands assume that `TPG_DATABASE_URL` is set and
+/// pointing to the location of the database.
+#[derive(Debug, Subcommand)]
+pub enum SetupCommand {
+    /// Add a new user to the system with a given set of roles
+    AddUser(AddUserParams),
+    /// Run the database migrations.
+    Migrate(MigrateParams),
+}
+
+#[derive(Debug, Args)]
+pub struct AddUserParams {
+    /// The Tari address of the user to add
+    #[arg(short, long)]
+    pub address: SerializedTariAddress,
+    /// The role to assign to the user. This parameter can be specified multiple times to assign multiple roles.
+    /// The available roles are: `user`, `read_all`, `write`, `super_admin`.
+    #[arg(short, long)]
+    pub role: Vec<Role>,
+}
+
+#[derive(Debug, Args)]
+pub struct MigrateParams {
+    /// The path to the migrations directory. The migrations are embedded in the binary by default, and so this
+    /// parameter is optional. If provided, the migrations at <path> will be executed instead.
+    #[arg(short, long)]
+    pub path: Option<String>,
+}
+
+pub async fn handle_setup_command(command: SetupCommand) {
+    match command {
+        SetupCommand::AddUser(params) => add_user(params).await,
+        SetupCommand::Migrate(params) => migrate_db(params).await,
+    }
+}
+
+async fn add_user(params: AddUserParams) {
+    async fn add(params: AddUserParams) -> Result<()> {
+        let db = SqliteDatabase::new(1).await?;
+        db.assign_roles(params.address.as_address(), &params.role).await?;
+        Ok(())
+    }
+    println!("Adding user with address: {} and roles {:?}", params.address, params.role);
+    match add(params).await {
+        Ok(_) => println!("User added successfully"),
+        Err(e) => println!("Error adding user: {e}"),
+    }
+}
+
+async fn migrate_db(params: MigrateParams) {
+    async fn migrate_embedded() -> Result<()> {
+        create_database_if_not_exist().await?;
+        println!("Running embedded migrations");
+        let db = SqliteDatabase::new(1).await?;
+        let pool = db.pool();
+        sqlx::migrate!("../tari_payment_engine/src/sqlite/migrations").run(pool).await?;
+        Ok(())
+    }
+
+    async fn migrate_custom(path: &str) -> Result<()> {
+        create_database_if_not_exist().await?;
+        println!("Running migrations at: {path}");
+        let db = SqliteDatabase::new(1).await?;
+        let path = Path::new(path);
+        let migrator = Migrator::new(path).await?;
+        let pool = db.pool();
+        migrator.run(pool).await?;
+        Ok(())
+    }
+
+    let result = match &params.path {
+        Some(path) => migrate_custom(path).await,
+        None => migrate_embedded().await,
+    };
+
+    match result {
+        Ok(_) => println!("Migrations complete"),
+        Err(e) => println!("Error running migrations: {e}"),
+    }
+}
+
+async fn create_database_if_not_exist() -> Result<()> {
+    let db = db_url();
+    if !database_exists(&db).await? {
+        println!("Creating new database at: {db}");
+        Sqlite::create_database(&db).await?;
+    }
+    Ok(())
+}
+
+async fn database_exists(db: &str) -> Result<bool> {
+    let result = Sqlite::database_exists(db).await?;
+    Ok(result)
+}


### PR DESCRIPTION
Updates installtino docs (primarily) following a clean installation test that followed the docs as written.

* Removes double-zip layer. Downloaded asset files are now only zipped once
* Upgrades upload asset action to v4
* TPG_PAYMENT_WALLET_ADDRESS was not consistently named across pre-flight and configuratnio code.
* Embed sqlx and the migrations in taritools so that they don't have to be installed separately (BIG WIN!)
* Update outdated cli-help file.
* Quit after printing help
* add `taritools setup add-user` command
* add `taritools setup migrate` command