### PR TITLE
feat: new address format

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,5 +33,5 @@ DATABASE_TYPE=sqlite
 TPG_SKIP_PREFLIGHT=No
 
 # Set this to the default authorized wallet to use for the "Send to" field in QR codes
-TPG_PAYMENT_WALLET_ADDRESS=0859fb3d6696579310c220d204cb21437d6658d0a05af1c8cd54fffd8725344352
+TPG_PAYMENT_WALLET_ADDRESS=143UtnSymZykCAm95xAKKKe8nowL6zif8qb1h7yHxgtD9XZ
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,20 +824,6 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
-]
-
-[[package]]
-name = "config"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
-dependencies = [
- "async-trait",
- "lazy_static",
- "nom",
- "pathdiff",
- "serde",
- "toml 0.5.11",
 ]
 
 [[package]]
@@ -1439,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "e2e"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -1454,7 +1449,7 @@ dependencies = [
  "serde_json",
  "shopify_tools",
  "tari-jwt",
- "tari_common_types 1.0.0-rc.5",
+ "tari_common_types",
  "tari_payment_engine",
  "tari_payment_server",
  "tokio",
@@ -1861,7 +1856,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.3.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1880,7 +1875,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.3.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1899,12 +1894,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1919,7 +1908,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2218,22 +2207,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2498,7 +2477,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde-value",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "thiserror",
  "typemap-ors",
 ]
@@ -2574,6 +2553,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "minotari_ledger_wallet_common"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
+dependencies = [
+ "bs58 0.5.1",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2631,7 +2618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c580bfdd8803cce319b047d239559a22f809094aaea4ac13902a1fdcfcd4261"
 dependencies = [
  "arrayref",
- "bs58",
+ "bs58 0.4.0",
  "byteorder",
  "data-encoding",
  "multihash",
@@ -3638,23 +3625,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -3701,7 +3676,7 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shopify_tools"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "graphql-parser",
@@ -3861,7 +3836,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.3.0",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -4228,25 +4203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tari-log4rs"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f387ee6565d938a07b5d217637adfb6d359f79e04b54e5e6a508513271d45f"
-dependencies = [
- "anyhow",
- "arc-swap",
- "derivative",
- "fnv",
- "humantime",
- "log",
- "serde",
- "serde-value",
- "serde_yaml 0.8.26",
- "thiserror",
- "typemap-ors",
-]
-
-[[package]]
 name = "tari_bulletproofs_plus"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4269,37 +4225,11 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "1.0.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ded359b26a2462827a8934d5b2c8ce46985b2b9455d9ba1dd9e1796e21995"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "anyhow",
- "blake2",
- "config 0.13.4",
- "dirs-next 1.0.2",
- "log",
- "multiaddr",
- "path-clean",
- "serde",
- "serde_json",
- "serde_yaml 0.9.34+deprecated",
- "sha2",
- "structopt",
- "tari-log4rs",
- "tari_crypto",
- "tari_features 1.0.0-rc.5",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "tari_common"
-version = "1.0.0-rc.8"
-source = "git+https://github.com/tari-project/tari.git?branch=nextnet#07131ad6091639dc46d22dd54bfc348ba93bdce0"
-dependencies = [
- "anyhow",
- "blake2",
- "config 0.14.0",
+ "config",
  "dirs-next 1.0.2",
  "log",
  "log4rs",
@@ -4307,19 +4237,18 @@ dependencies = [
  "path-clean",
  "serde",
  "serde_json",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "sha2",
  "structopt",
- "tari_crypto",
- "tari_features 1.0.0-rc.8",
+ "tari_features",
  "tempfile",
  "thiserror",
 ]
 
 [[package]]
 name = "tari_common_sqlite"
-version = "1.0.0-rc.8"
-source = "git+https://github.com/tari-project/tari.git?branch=nextnet#07131ad6091639dc46d22dd54bfc348ba93bdce0"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -4332,37 +4261,17 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "1.0.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4548daa4a6ed350d8de1f37e137d669b15b679f514a589d5076aafa41fc5785a"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "base64 0.21.7",
+ "bitflags 2.6.0",
  "blake2",
  "borsh",
+ "bs58 0.5.1",
  "chacha20poly1305",
  "digest",
- "newtype-ops",
- "once_cell",
- "primitive-types",
- "rand 0.8.5",
- "serde",
- "tari_common 1.0.0-rc.5",
- "tari_crypto",
- "tari_utilities",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "tari_common_types"
-version = "1.0.0-rc.8"
-source = "git+https://github.com/tari-project/tari.git?branch=nextnet#07131ad6091639dc46d22dd54bfc348ba93bdce0"
-dependencies = [
- "base64 0.21.7",
- "blake2",
- "borsh",
- "chacha20poly1305",
- "digest",
+ "minotari_ledger_wallet_common",
  "newtype-ops",
  "once_cell",
  "primitive-types",
@@ -4370,7 +4279,7 @@ dependencies = [
  "serde",
  "strum",
  "strum_macros",
- "tari_common 1.0.0-rc.8",
+ "tari_common",
  "tari_crypto",
  "tari_utilities",
  "thiserror",
@@ -4402,19 +4311,13 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "1.0.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2013efce6b8e00f0671534b9d444d12085f2e3778b7ebba3b1be297b7f9b86a"
-
-[[package]]
-name = "tari_features"
-version = "1.0.0-rc.8"
-source = "git+https://github.com/tari-project/tari.git?branch=nextnet#07131ad6091639dc46d22dd54bfc348ba93bdce0"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 
 [[package]]
 name = "tari_key_manager"
-version = "1.0.0-rc.8"
-source = "git+https://github.com/tari-project/tari.git?branch=nextnet#07131ad6091639dc46d22dd54bfc348ba93bdce0"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "argon2",
  "async-trait",
@@ -4435,7 +4338,7 @@ dependencies = [
  "strum_macros",
  "subtle",
  "tari_common_sqlite",
- "tari_common_types 1.0.0-rc.8",
+ "tari_common_types",
  "tari_crypto",
  "tari_service_framework",
  "tari_utilities",
@@ -4446,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "tari_payment_engine"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "blake2",
  "chrono",
@@ -4461,8 +4364,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "tari_common 1.0.0-rc.5",
- "tari_common_types 1.0.0-rc.5",
+ "tari_common",
+ "tari_common_types",
  "tari_crypto",
  "thiserror",
  "tokio",
@@ -4471,7 +4374,7 @@ dependencies = [
 
 [[package]]
 name = "tari_payment_server"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "actix-http",
  "actix-jwt-auth-middleware",
@@ -4494,7 +4397,7 @@ dependencies = [
  "sha2",
  "shopify_tools",
  "tari-jwt",
- "tari_common_types 1.0.0-rc.5",
+ "tari_common_types",
  "tari_payment_engine",
  "tempfile",
  "thiserror",
@@ -4504,8 +4407,8 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "1.0.0-rc.8"
-source = "git+https://github.com/tari-project/tari.git?branch=nextnet#07131ad6091639dc46d22dd54bfc348ba93bdce0"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4519,8 +4422,8 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "1.0.0-rc.8"
-source = "git+https://github.com/tari-project/tari.git?branch=nextnet#07131ad6091639dc46d22dd54bfc348ba93bdce0"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "futures 0.3.30",
 ]
@@ -4545,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "taritools"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4569,8 +4472,8 @@ dependencies = [
  "shopify_tools",
  "sqlx",
  "tari-jwt",
- "tari_common 1.0.0-rc.5",
- "tari_common_types 1.0.0-rc.5",
+ "tari_common",
+ "tari_common_types",
  "tari_crypto",
  "tari_key_manager",
  "tari_payment_engine",
@@ -4848,7 +4751,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -4859,7 +4762,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4895,7 +4798,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tpg_common"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "sqlx",
@@ -5463,15 +5366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -301,7 +301,7 @@ variable that contains the secret key, and populate that environment variable fr
 ```toml
 [[profiles]]
 name = "More secure SuperAdmin"
-address = "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d"
+address = "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt"
 secret_key_envar = "TEST_KEY_SECRET"
 roles = ["super_admin"]
 server = "http://172.17.0.2:4444"
@@ -339,7 +339,7 @@ confirmed.
      ```toml
      [[profiles]]
      name="TPS Hot Wallet"
-     address="b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d"
+     address="14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt"
      # For security reasons, we suggest you don't store the secret key in the config file.
      secret_key=""
      # The secret key will be loaded from the specified enviroment variable instead.

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "e2e"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+shopify_tools = { version = "0.3.0", path = "../shopify_tools" }
+tari_payment_engine = { version = "0.3.0", path = "../tari_payment_engine", features = ["test_utils"] }
+tari_payment_server = { version = "0.3.0", path = "../tari_payment_server" }
+tpg_common = { version = "0.3.0", path = "../tpg_common" }
+
 log = "0.4.21"
-tari_common_types = "1.0.0-pre.10"
-shopify_tools = { version = "0.2.1", path = "../shopify_tools" }
-tari_payment_engine = { version = "0.2.1", path = "../tari_payment_engine", features = ["test_utils"] }
-tari_payment_server = { version = "0.2.1", path = "../tari_payment_server" }
-tpg_common = { version = "0.2.1", path = "../tpg_common" }
+tari_common_types = {version = "1.3.1-pre.1", git = "https://github.com/tari-project/tari.git", package = "tari_common_types", tag = "v1.3.1-pre.1" }
 tari-jwt = {  version = "0.1.0", git = "https://github.com/tari-project/tari-jwt.git", branch = "main" }
 rand = "0.8.5"
 reqwest = { version = "0.12.2", features = ["json"] }

--- a/e2e/src/helpers.rs
+++ b/e2e/src/helpers.rs
@@ -102,30 +102,30 @@ mod test {
     fn is_subset_complex_object_fail() {
         let complete = r#"
         {
-          "address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+          "address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
           "total_orders":165000000,
           "orders":[
             {"id":1,"order_id":"1","customer_id":"alice",
-             "memo":"address: [680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b]",
+             "memo":"address: [14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp]",
              "total_price":100000000,
              "currency":"XTR",
              "status":"New"},
             {"id":3,"order_id":"3","customer_id":"alice",
-            "memo":"address: [680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b]",
+            "memo":"address: [14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp]",
             "total_price":65000000,"currency":"XTR",
             "status":"New"}
           ]}
         "#;
-        let part = r#"{ "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d" }"#;
+        let part = r#"{ "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt" }"#;
         assert!(!json_is_subset_of(part, complete));
         let part = r#"{
-          "address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+          "address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
           "total_orders":165
         }"#;
         assert!(!json_is_subset_of(part, complete));
         let part = r#"
         {
-          "address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+          "address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
           "total_orders":165000000,
           "orders":[]}
         "#;

--- a/e2e/tests/cucumber/setup.rs
+++ b/e2e/tests/cucumber/setup.rs
@@ -25,7 +25,7 @@ fn seed_orders() -> [NewOrder; 5] {
             currency: "XTR".into(),
             customer_id: "alice".into(),
             memo: Some("Manually inserted by Keith".into()),
-            address: "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d".parse().ok(),
+            address: "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt".parse().ok(),
             total_price: MicroTari::from_tari(100),
             original_price: None,
             created_at: Utc.with_ymd_and_hms(2024, 3, 10, 15, 0, 0).unwrap(),
@@ -35,7 +35,7 @@ fn seed_orders() -> [NewOrder; 5] {
             currency: "XTR".into(),
             customer_id: "bob".into(),
             memo: Some("Manually inserted by Charlie".into()),
-            address: "680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b".parse().ok(),
+            address: "14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp".parse().ok(),
             total_price: MicroTari::from_tari(200),
             original_price: None,
             created_at: Utc.with_ymd_and_hms(2024, 3, 10, 15, 30, 0).unwrap(),
@@ -45,7 +45,7 @@ fn seed_orders() -> [NewOrder; 5] {
             currency: "XTR".into(),
             customer_id: "alice".into(),
             memo: Some("Manually inserted by Sam".into()),
-            address: "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d".parse().ok(),
+            address: "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt".parse().ok(),
             total_price: MicroTari::from_tari(65),
             original_price: None,
             created_at: Utc.with_ymd_and_hms(2024, 3, 11, 16, 0, 0).unwrap(),
@@ -55,7 +55,7 @@ fn seed_orders() -> [NewOrder; 5] {
             currency: "XTR".into(),
             customer_id: "bob".into(),
             memo: Some("Manually inserted by Ray".into()),
-            address: "680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b".parse().ok(),
+            address: "14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp".parse().ok(),
             total_price: MicroTari::from_tari(350),
             original_price: None,
             created_at: Utc.with_ymd_and_hms(2024, 3, 11, 17, 0, 0).unwrap(),
@@ -65,7 +65,7 @@ fn seed_orders() -> [NewOrder; 5] {
             currency: "XMR".into(),
             customer_id: "admin".into(),
             memo: Some("Manually inserted by Charlie".into()),
-            address: "aa3c076152c1ae44ae86585eeba1d348badb845d1cab5ef12db98fafb4fea55d6c".parse().ok(),
+            address: "14sa5AzjqqrzfiyqGkajoNcFrqkCK7syB4rvNNL65f2PjLD".parse().ok(),
             total_price: MicroTari::from_tari(25),
             original_price: None,
             created_at: Utc.with_ymd_and_hms(2024, 3, 12, 18, 0, 0).unwrap(),
@@ -76,35 +76,35 @@ fn seed_orders() -> [NewOrder; 5] {
 fn seed_payments() -> [NewPayment; 5] {
     [
         NewPayment {
-            sender: "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d".parse().unwrap(), // Alice
+            sender: "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt".parse().unwrap(), // Alice
             amount: MicroTari::from_tari(15),
             txid: "alicepayment001".to_string(),
             memo: None,
             order_id: None,
         },
         NewPayment {
-            sender: "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d".parse().unwrap(), // Alice
+            sender: "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt".parse().unwrap(), // Alice
             amount: MicroTari::from_tari(100),
             txid: "alicepayment002".to_string(),
             memo: None,
             order_id: None,
         },
         NewPayment {
-            sender: "680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b".parse().unwrap(), // Bob
+            sender: "14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp".parse().unwrap(), // Bob
             amount: MicroTari::from_tari(50),
             txid: "bobpayment001".to_string(),
             memo: None,
             order_id: None,
         },
         NewPayment {
-            sender: "680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b".parse().unwrap(), // Bob
+            sender: "14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp".parse().unwrap(), // Bob
             amount: MicroTari::from_tari(500),
             txid: "bobpayment002".to_string(),
             memo: None,
             order_id: None,
         },
         NewPayment {
-            sender: "c483a8f207d30d92633f4efc5e6a48a2e14aa45f94a4dd183749232e6bc39d64f7".parse().unwrap(), // Anon
+            sender: "142Eyn9FMCsBVRsFBc2zqfgBxPTTpX9dYjtrPABa9whREdia".parse().unwrap(), // Anon
             amount: MicroTari::from_tari(700),
             txid: "anonpayment001".to_string(),
             memo: None,
@@ -125,7 +125,7 @@ fn super_admin() -> UserInfo {
     UserInfo {
         username: "Super".into(),
         secret: PrivateKey::from_hex("5b1488f90c3385b0a4d3ab9f6992f2592d35f77a57655160a9236ffadb78260c").unwrap(),
-        address: TariAddress::from_hex("02f671c8294931a6395b51a1f32921f429d22c1e34def8f9f81892034fe2963cf7").unwrap(),
+        address: TariAddress::from_base58("14t3efXHQphjE8GdVhSzxZH8VWeVphfqjiXsUvVEpTJJBA").unwrap(),
         roles: vec![Role::SuperAdmin],
     }
 }
@@ -155,22 +155,19 @@ impl SeedUsers {
         users.insert("Admin", UserInfo {
             username: "Admin".into(),
             secret: PrivateKey::from_hex("6fd9d9a5836eaf71c396c9af1915fe990c4c396b0c6f57c19db968af9d9ffd04").unwrap(),
-            address: TariAddress::from_hex("aa3c076152c1ae44ae86585eeba1d348badb845d1cab5ef12db98fafb4fea55d6c")
-                .unwrap(),
+            address: TariAddress::from_base58("14sa5AzjqqrzfiyqGkajoNcFrqkCK7syB4rvNNL65f2PjLD").unwrap(),
             roles: vec![Role::User, Role::Write, Role::ReadAll],
         });
         users.insert("Alice", UserInfo {
             username: "Alice".into(),
             secret: PrivateKey::from_hex("c63b5b436d007bec0566bff2f3512f3f962a6d43161fe48616e8dad58fd2b80d").unwrap(),
-            address: TariAddress::from_hex("b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d")
-                .unwrap(),
+            address: TariAddress::from_base58("14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt").unwrap(),
             roles: vec![Role::User],
         });
         users.insert("Bob", UserInfo {
             username: "Bob".into(),
             secret: PrivateKey::from_hex("6ee8a6d1078755bfebd91751bd5d2fb76544ab49f23fe61d5c9a2857b7eea503").unwrap(),
-            address: TariAddress::from_hex("680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b")
-                .unwrap(),
+            address: TariAddress::from_base58("14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp").unwrap(),
             roles: vec![Role::User],
         });
         Self { users }

--- a/e2e/tests/features/accounts.feature
+++ b/e2e/tests/features/accounts.feature
@@ -27,13 +27,13 @@ Feature: Accounts endpoint
     Given some role assignments
     When Alice authenticates with nonce = 1 and roles = "user"
     When Bob authenticates with nonce = 1 and roles = "user"
-    When Alice GETs to "/api/account/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Alice GETs to "/api/account/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
 
   Scenario: User with ReadAll role can access another account
     Given some role assignments
     When Admin authenticates with nonce = 1 and roles = "user,read_all"
-    When Admin GETs to "/api/account/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Admin GETs to "/api/account/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
@@ -51,7 +51,7 @@ Feature: Accounts endpoint
     Given some role assignments
     Given a super-admin user (Super)
     When Super authenticates with nonce = 1
-    When Super GETs to "/api/account/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Super GETs to "/api/account/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """

--- a/e2e/tests/features/admin_endpoints.feature
+++ b/e2e/tests/features/admin_endpoints.feature
@@ -7,7 +7,7 @@ Feature: super-admin
       When User POSTs to "/api/roles" with body
         """
         [{
-          "address": "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+          "address": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
           "apply": ["super_admin", "write"]
         }]
         """
@@ -19,7 +19,7 @@ Feature: super-admin
     When Alice POSTs to "/api/roles" with body
         """
         [{
-          "address": "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+          "address": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
           "apply": ["super_admin", "write"]
         }]
         """
@@ -31,7 +31,7 @@ Feature: super-admin
     When Super POSTs to "/api/roles" with body
         """
         [{
-          "address": "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+          "address": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
           "apply": ["read_all", "write"],
           "revoke": ["super_admin"]
         }]
@@ -39,28 +39,28 @@ Feature: super-admin
     Then I receive a 200 Ok response with the message ''
 
   Scenario: A random address has the default role
-    Then address 3a5f3651ca97dc6dea42670d7a62dc746d6d4a6f72ef25d48ab36252d71a1627b6 has roles "user"
+    Then address 142Eyn9FMCsBVRsFBc2zqfgBxPTTpX9dYjtrPABa9whREdia has roles "user"
 
   Scenario: Roles change after Super_Admin edits them
     Given some role assignments
     When Super authenticates with nonce = 1
-    Then address 98348e08c9076879bfe3e26f11fb7ef0391a2f4d3bf20dd58507ff90297f813529 has roles "user"
+    Then address 14sa5AzjqqrzfiyqGkajoNcFrqkCK7syB4rvNNL65f2PjLD has roles "user"
     When Super POSTs to "/api/roles" with body
         """
         [{
-          "address": "98348e08c9076879bfe3e26f11fb7ef0391a2f4d3bf20dd58507ff90297f813529",
+          "address": "14sa5AzjqqrzfiyqGkajoNcFrqkCK7syB4rvNNL65f2PjLD",
           "apply": ["write","read_all"]
         }]
         """
-    Then address 98348e08c9076879bfe3e26f11fb7ef0391a2f4d3bf20dd58507ff90297f813529 has roles "user,write,read_all"
+    Then address 14sa5AzjqqrzfiyqGkajoNcFrqkCK7syB4rvNNL65f2PjLD has roles "user,write,read_all"
     When Super POSTs to "/api/roles" with body
         """
         [{
-          "address": "98348e08c9076879bfe3e26f11fb7ef0391a2f4d3bf20dd58507ff90297f813529",
+          "address": "14sa5AzjqqrzfiyqGkajoNcFrqkCK7syB4rvNNL65f2PjLD",
           "revoke": ["write"]
         }]
         """
-    Then address 98348e08c9076879bfe3e26f11fb7ef0391a2f4d3bf20dd58507ff90297f813529 has roles "user,read_all"
+    Then address 14sa5AzjqqrzfiyqGkajoNcFrqkCK7syB4rvNNL65f2PjLD has roles "user,read_all"
 
 
   Scenario: You cannot revoke the default role
@@ -69,11 +69,11 @@ Feature: super-admin
     When Super POSTs to "/api/roles" with body
         """
         [{
-          "address": "98348e08c9076879bfe3e26f11fb7ef0391a2f4d3bf20dd58507ff90297f813529",
+          "address": "14sa5AzjqqrzfiyqGkajoNcFrqkCK7syB4rvNNL65f2PjLD",
           "revoke": ["user"]
         }]
         """
-    Then address 98348e08c9076879bfe3e26f11fb7ef0391a2f4d3bf20dd58507ff90297f813529 has roles "user"
+    Then address 14sa5AzjqqrzfiyqGkajoNcFrqkCK7syB4rvNNL65f2PjLD has roles "user"
 
   Scenario: Non-super users have any subset of roles they are assigned
     Given some role assignments
@@ -81,10 +81,10 @@ Feature: super-admin
     When Super POSTs to "/api/roles" with body
         """
         [{
-          "address": "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+          "address": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
           "apply": ["read_all", "write", "payment_wallet"]
         }]
         """
-    Then address b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d has roles "read_all,write,payment_wallet,user"
-    Then address b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d has roles "read_all,payment_wallet,user"
-    Then address b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d has roles "payment_wallet"
+    Then address 14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt has roles "read_all,write,payment_wallet,user"
+    Then address 14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt has roles "read_all,payment_wallet,user"
+    Then address 14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt has roles "payment_wallet"

--- a/e2e/tests/features/auth.feature
+++ b/e2e/tests/features/auth.feature
@@ -18,13 +18,12 @@ Feature: Users receive an access token when authenticating with a login token
   Scenario: User authenticates with an invalid signature
     When I authenticate with the auth header
       """
-      tpg_auth_token: eyJhbGciOiJSaXN0cmV0dG8yNTYifQ.\
-      eyJhZGRyZXNzIjp7Im5ldHdvcmsiOiJuZXh0bmV0IiwicHV\
-      ibGljX2tleSI6IjEyYTI1MDRhNzhmMDg5MzBjMmQzMzU3MD\
-      hmYWU4MDY5NmIyMTdkMjNiZDJkNDczZTEyN2Q4ZjVhMzBlM\
-      jgxNjUifSwibm9uY2UiOjE3MTE0NDUxMTgsImRlc2lyZWRf\
-      cm9sZXMiOlsidXNlciIsIndyaXRlIl19.\
-      bad_sig_Uip03HFi5q65zE-QBq8iyEuT-IkLy9KeSHmB3UGkPIJXSDrKDVU_lg6JfBY4ch7BxwyH5iLDEiDzAQ
+      tpg_auth_token: eyJhbGciOiJSaXN0cmV0dG8yNTYiLCJ0eXAiOiJKV1QifQ.\
+      eyJhZGRyZXNzIjp7IlNpbmdsZSI6eyJuZXR3b3JrIjoibWFpbm5ldCIsImZlYXR\
+      1cmVzIjozLCJwdWJsaWNfc3BlbmRfa2V5IjoiYzAwOTU4NGRhYzZhZDljYTA5Nj\
+      RlM2RjOTM4OTJjNjA3Y2EzN2UwNDliNGMzMDYzN2ZhNDc3ZDBkNjAxMTc0NCJ9f\
+      Swibm9uY2UiOjE3MjUzMDMyNTksImRlc2lyZWRfcm9sZXMiOlsidXNlciJdfQ.\
+      xxxxxxlx5ZXz-UKFIWIL6a6KmdQi9JkUdROLLfvlyx3_j5__qDpgF5MnDDky0ofDeW39EFdpeVMyDLK4I7bCDg
       """
     Then I receive a 401 Unauthorized response with the message 'Authentication Error. Login token signature is invalid. malformed token signature'
 

--- a/e2e/tests/features/claim_order.feature
+++ b/e2e/tests/features/claim_order.feature
@@ -10,20 +10,26 @@ Feature: Order claiming
     """
     {
       "orderId": "1",
-      "address": "aa3c076152c1ae44ae86585eeba1d348badb845d1cab5ef12db98fafb4fea55d6c",
+      "address": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "signature": "foobar"
     }
     """
     Then I receive a 400 BadRequest response with the message 'Invalid signature'
 
+  # ----------------------------- Tari Address -----------------------------
+  # Network: mainnet
+  # Secret key: bf9da371add03729f9df1ab8f6356a7104868fe75de9d5235d33af28cfcae701
+  # Public key: 10c2e78e1bbbe58779eade51cf6d66f26288d934e9eda26fb20c8bcb88825d2a
+  # Address      : 145yntp6GHTuDuTVPtbyPdo8rVjRppjdfyoxZeY958kh1Mn
+  #------------------------------------------------------------------------
   Scenario: An unauthenticated user can claim an order with the correct signature, even if they already have a previous account
     When Customer #142 ["anon@example.com"] places order "order10256" for 2400 XTR, with memo
     When User POSTs to "/order/claim" with body
     """
     {
-      "address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+      "address":"145yntp6GHTuDuTVPtbyPdo8rVjRppjdfyoxZeY958kh1Mn",
       "order_id":"order10256",
-      "signature":"70cff86acc645b460cb4f1e0ffecfa11871d5d50ea349774964e851a451f3202ee4a39b038ddce19cb88b6ef57259bd9f6aa26cf2594f5b04ec14db05320f900"}
+      "signature":"6689435195fda30c9c3805b844b45adadac2d5b5ca647dca342531e50bd5ff658b0aa458d184e720a6fcd5c7be4efec65e7e7e78e1c86003bf00147962cb540d"}
     """
     Then I receive a 200 Ok response
     And I receive a partial JSON response:
@@ -34,27 +40,27 @@ Feature: Order claiming
     """
     {
       "order": { "order_id": "order10256", "total_price": 2400000000, "status": "New" },
-      "claimant": "680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b"
+      "claimant": "145yntp6GHTuDuTVPtbyPdo8rVjRppjdfyoxZeY958kh1Mn"
     }
     """
 
   # ----------------------------- Memo Signature -----------------------------
-  # Wallet address: 480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88
+  # Wallet address: 14NPqUxFyJwbZ6wJ8hpuTuX5oWbQt7XeMJWXMZdMSiA19Fj
   # Public key    : 480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a
   # emoji id      : 🎢🌋🐲🎠🍄🍬🌂🍊👕🎳🍼💕👖👒🚒🍆🍈🔭🚑🐭🌝🎓👖🚂🎨🌴💀🍄🌟🌰🔪🐜🐳
   # Secret        : ac8bac66b8efc8f2055ba8dcd95ad5f7f9e791d876a50642d563426fc86de109
   # Network       : mainnet
-  # auth: {"address":"480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88","order_id":"anon101","signature":"2ee4933f2a845e424a784d0c35d84bfb2836191aa5ffc4adc20de3b733da8478c0a0afcf941ed8a26d195eb1f748d2101ed6434af49823994334778385fc0b04"}
+  # auth:  {"address":"14NPqUxFyJwbZ6wJ8hpuTuX5oWbQt7XeMJWXMZdMSiA19Fj","order_id":"anon100","signature":"be215f32c4b7a9a7a4da600a53bfdc7ca735e64cf5f0ecac2b5904ac24a1fb04376c2c7f3d96ca95e0e16a124f80dc846702e14df6387ad744ad5737f14fa90c"}
   # ------------------------------------------------------------------------
   Scenario: Previously unlinked accounts can claim an order with the correct signature, and the order can be paid.
-    Given a payment of 100 XTR from address 480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88 in tx tx4804forAnon100
+    Given a payment of 100 XTR from address 14NPqUxFyJwbZ6wJ8hpuTuX5oWbQt7XeMJWXMZdMSiA19Fj in tx tx4804forAnon100
     When Customer #999 ["who@example.com"] places order "anon100" for 60 XTR, with memo
     When User POSTs to "/order/claim" with body
     """
     {
-       "address":"480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88",
+       "address":"14NPqUxFyJwbZ6wJ8hpuTuX5oWbQt7XeMJWXMZdMSiA19Fj",
        "order_id":"anon100",
-       "signature":"1295995d5698365ecc82ee7acf4acd11dfe678a9b860fd2054d1d3b5b9c14951daa3a09dd00fa9869fedf5e321b877a22ad3cc7291e93d3d320e2d4ac8134d05"
+       "signature":"72dcd2ff713f5f38c45f0f87426646eeac49a360613bf9d7195ce009dd23df392b908baa26206c129b975caa382cc0bad603f13e0c8f0cbf49809c3546a10105"
     }
     """
     Then I receive a 200 Ok response
@@ -62,7 +68,7 @@ Feature: Order claiming
     """
     {
       "order": { "order_id": "anon100", "total_price": 60000000, "status": "New" },
-      "claimant": "480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88"
+      "claimant": "14NPqUxFyJwbZ6wJ8hpuTuX5oWbQt7XeMJWXMZdMSiA19Fj"
     }
     """
     Then the OrderPaid trigger fires with
@@ -78,9 +84,9 @@ Feature: Order claiming
     When User POSTs to "/order/claim" with body
     """
     {
-       "address":"480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88",
+       "address":"14NPqUxFyJwbZ6wJ8hpuTuX5oWbQt7XeMJWXMZdMSiA19Fj",
        "order_id":"anon101",
-       "signature":"2ee4933f2a845e424a784d0c35d84bfb2836191aa5ffc4adc20de3b733da8478c0a0afcf941ed8a26d195eb1f748d2101ed6434af49823994334778385fc0b04"
+       "signature":"e88a14e2e1de92bc68cf982c0cfc9c3c39c3f4a7f712b6b0294961da6b9f70059f9025d635e3221e1b7c79ee33665881f8320243ae4a59b9226b45f86eb63d05"
     }
     """
     Then I receive a 200 Ok response
@@ -92,6 +98,6 @@ Feature: Order claiming
     """
     {
       "order": { "order_id": "anon101", "total_price": 28000000, "status": "New" },
-      "claimant": "480487461530011b99563cb69a96f11719ddf08307459aee4d0cab15090bda7a88"
+      "claimant": "14NPqUxFyJwbZ6wJ8hpuTuX5oWbQt7XeMJWXMZdMSiA19Fj"
     }
     """

--- a/e2e/tests/features/expiry.feature
+++ b/e2e/tests/features/expiry.feature
@@ -3,7 +3,6 @@ Feature: Expire old orders
   Background:
     # For testing, the expiry limits are 2s for unclaimed and 4s for unpaid
 
-
   Scenario: Expire unclaimed orders
     Given a blank slate
     When Customer #1 ["Alex"] places order "order1" for 1 XTR, with memo

--- a/e2e/tests/features/full_accounts.feature
+++ b/e2e/tests/features/full_accounts.feature
@@ -1,3 +1,4 @@
+@full_accounts
 Feature: Full accounts endpoint (/api/history)
   Background:
     Given a database with some accounts
@@ -23,7 +24,7 @@ Feature: Full accounts endpoint (/api/history)
       "total_orders":165000000,
       "current_orders":165000000
     },
-    "addresses":[ {"address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d" } ],
+    "addresses":[ {"address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt" } ],
     "customer_ids":[{"customer_id":"alice"}],
     "orders":[
       {"id":1,"order_id":"1","total_price":100000000,"status":"New"},
@@ -37,7 +38,7 @@ Feature: Full accounts endpoint (/api/history)
 
   Scenario: Standard user cannot access another user's account history with an address
     When Alice authenticates with nonce = 1 and roles = "user"
-    When Alice GETs to "/api/history/address/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Alice GETs to "/api/history/address/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
 
   Scenario: Standard user cannot access another user's account history with an account id
@@ -47,7 +48,7 @@ Feature: Full accounts endpoint (/api/history)
 
   Scenario: User with ReadAll role can access any account history with an address
     When Admin authenticates with nonce = 1 and roles = "user,read_all"
-    When Admin GETs to "/api/history/address/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Admin GETs to "/api/history/address/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
@@ -60,7 +61,7 @@ Feature: Full accounts endpoint (/api/history)
         "total_orders":550000000,
         "current_orders":550000000
       },
-      "addresses":[ {"address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b"}],
+      "addresses":[ {"address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp"}],
       "customer_ids":[{"customer_id":"bob"}],
       "orders":[
         {"id":2,"order_id":"2","customer_id":"bob","total_price":200000000,"status":"New"},
@@ -88,7 +89,7 @@ Feature: Full accounts endpoint (/api/history)
         "total_orders":550000000,
         "current_orders":550000000
       },
-      "addresses":[ {"address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b"}],
+      "addresses":[ {"address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp"}],
       "customer_ids":[{"customer_id":"bob"}],
       "orders":[
         {"id":2,"order_id":"2","customer_id":"bob","total_price":200000000,"status":"New"},
@@ -104,7 +105,7 @@ Feature: Full accounts endpoint (/api/history)
   Scenario: SuperAdmin role can access another account
     Given a super-admin user (Super)
     When Super authenticates with nonce = 1
-    When Super GETs to "/api/history/address/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Super GETs to "/api/history/address/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
@@ -117,7 +118,7 @@ Feature: Full accounts endpoint (/api/history)
         "total_orders":550000000,
         "current_orders":550000000
       },
-      "addresses":[ {"address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b"}],
+      "addresses":[ {"address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp"}],
       "customer_ids":[{"customer_id":"bob"}],
       "orders":[
         {"id":2,"order_id":"2","customer_id":"bob","total_price":200000000,"status":"New"},

--- a/e2e/tests/features/order_payment_matching.feature
+++ b/e2e/tests/features/order_payment_matching.feature
@@ -1,3 +1,4 @@
+@order_fulfillment
 Feature: Order Fulfillment
   Background:
     Given a server configuration
@@ -6,7 +7,7 @@ Feature: Order Fulfillment
     Given an authorized wallet with secret df158b8389c68aac01a91276b742d2527f951d3c7289e4ccdecfa0672947270e
     """
       {
-        "address": "c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "address": "14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
         "ip_address": "192.168.1.100"
       }
     """
@@ -15,9 +16,9 @@ Feature: Order Fulfillment
     When Customer #1 ["alice"] places order "alice001" for 2400 XTR, with memo
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "order_id":"alice001",
-      "signature":"56e39d539f1865742b41993bdc771a2d0c16b35c83c57ca6173f8c1ced34140aeaf32bfdc0629e73f971344e7e45584cbbb778dc98564d0ec5c419e6f9ff5d06"
+      "signature":"92e9d026e3a4e785ade1ab81e69204bf30c256966964f8f048ec9f06018f1c00ab7ff501a5e0bd7135f38d3e631bc57f851e6f0788f9edc0f908a42d16047701"
     }
     """
     Then Customer #1 has current orders worth 2400 XTR
@@ -26,14 +27,14 @@ Feature: Order Fulfillment
     When a payment arrives from x-forwarded-for 192.168.1.100
     """
     {"payment": {
-      "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "amount":2500000000,
       "txid":"payment001"
     },
     "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
       "nonce":1,
-      "signature":"06d0cd5b00172990300481ea509de8c2e184595ed32b587b701aff7134279023b7dfde81542b6b383ff9594d6f4f0dea30347d110bbb496f5041738865f5e80c"
+      "signature":"5ed91d58e589bea2f2291155b78005b48a789c3018fdf528f6f4052b2428e532953aa065e08ef91575a610b2ebcf88e63fbf2e21bfd0e8b90b778c16ffc2740e"
     }}
     """
     Then I receive a 200 Ok response with the message '"success":true'
@@ -45,9 +46,9 @@ Feature: Order Fulfillment
     """
     { "confirmation": {"txid": "payment001"},
       "auth": {
-        "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
         "nonce":2,
-        "signature":"c2f727328c7387282b6e65c8fd0ffcd7a03355cb9046e3602991be9991a7860496ec9ecfa85c0463d37b6a3a2261e50964dfcd5127d41fa907c14448b2a4ce0b"
+        "signature":"16729e3c9b08022a16edfa0bf2e1cfc1d8dadd5e6387b4fd76005ac8a20c0f53087434524748981e9c61f9b7ce122fdf1a45299b132cd4495b19b7d1208cea01"
       }
     }
     """
@@ -71,14 +72,14 @@ Feature: Order Fulfillment
     When a payment arrives from x-forwarded-for 192.168.1.100
     """
     {"payment": {
-      "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "amount":2500000000,
       "txid":"payment001"
     },
     "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
       "nonce":1,
-      "signature":"06d0cd5b00172990300481ea509de8c2e184595ed32b587b701aff7134279023b7dfde81542b6b383ff9594d6f4f0dea30347d110bbb496f5041738865f5e80c"
+      "signature":"6e48cb91e4a94b2dd04305f81932ed61436a635a44536ab513d430464b946f594fd6e29ddd511d5c756cabb27232301cf6ad625f875f08b44b4346f29b151b0e"
     }}
     """
     Then I receive a 200 Ok response with the message '"success":true'
@@ -88,7 +89,7 @@ Feature: Order Fulfillment
     """
       {
         "payment": {
-          "sender": "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+          "sender": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
           "txid": "payment001",
           "amount": 2500000000,
           "status": "received"
@@ -99,9 +100,9 @@ Feature: Order Fulfillment
     """
     { "confirmation": {"txid": "payment001"},
       "auth": {
-        "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
         "nonce":2,
-        "signature":"c2f727328c7387282b6e65c8fd0ffcd7a03355cb9046e3602991be9991a7860496ec9ecfa85c0463d37b6a3a2261e50964dfcd5127d41fa907c14448b2a4ce0b"
+        "signature":"3a9edfc5d607943e78557bf220c199486b4cb1964dee2e5be5c3173c40e4e1684131ec88b317a61ea0574b3cbb8ffdec6bb5f4937067b445eabdc3e15121a003"
       }
     }
     """
@@ -111,7 +112,7 @@ Feature: Order Fulfillment
     """
       {
         "payment": {
-          "sender": "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+          "sender": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
           "txid": "payment001",
           "amount": 2500000000,
           "status": "confirmed"
@@ -121,9 +122,9 @@ Feature: Order Fulfillment
     When Customer #1 ["alice"] places order "alice001" for 2400 XTR, with memo
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "order_id":"alice001",
-      "signature":"56e39d539f1865742b41993bdc771a2d0c16b35c83c57ca6173f8c1ced34140aeaf32bfdc0629e73f971344e7e45584cbbb778dc98564d0ec5c419e6f9ff5d06"
+      "signature":"92e9d026e3a4e785ade1ab81e69204bf30c256966964f8f048ec9f06018f1c00ab7ff501a5e0bd7135f38d3e631bc57f851e6f0788f9edc0f908a42d16047701"
     }
     """
     Then Customer #1 has current orders worth 0 XTR
@@ -147,31 +148,31 @@ Feature: Order Fulfillment
     When Customer #1 ["alice"] places order "alice001" for 2400 XTR, with memo
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "order_id":"alice001",
       "signature":"56e39d539f1865742b41993bdc771a2d0c16b35c83c57ca6173f8c1ced34140aeaf32bfdc0629e73f971344e7e45584cbbb778dc98564d0ec5c419e6f9ff5d06"
     }
     """
     When Customer #2 ["bob"] places order "bob700" for 700 XTR, with memo
     """
-    { "address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+    { "address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
       "order_id":"bob700",
-      "signature":"18cf83225c67e9030d7126443af97659d7ac8ca9b1cd95358c7fb2b33cd0d767bfb7c398975408771f0f6ad0832e987b6ba6b913b1932682ccb1b2bc068e1a06"
+      "signature":"5ea6273f959276b0c1938efb9688aa9d08eec76688a92b4c626c9329dc4bab4afa2c3aac67e55d1cb036ba099cd6cdf0e42f1fdc6407e78e166c22ec4921ac01"
     }
     """
     # Get a payment from an unknown user
     # Secret key: 0148217c5dd247c6ccb511c3548cc8b6b5075cbae85f4c3743073fc51a6d8301
-    # Address: 1a4dd47666cb4010401e50ecf9dcd553bdc4c1b3c96ce028b14032cb7e9c154984
+    # Address: 148pD3w44RtpDZ63RxzJoaCJYSUUEpfpFLyacw1qzAgLmo7
     When a payment arrives from x-forwarded-for 192.168.1.100
     """
      {
        "auth": {
-         "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+         "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
          "nonce":1,
-         "signature":"86988f995e8454cb2892f71e781857025d82af13f88f148d0559741fa43acd7036cee2990190a131f45e9e9448714951edcfe6a55cbd037fdf0f06a301b9900f"
+         "signature":"72e1a01b1f8850c55f15898c1b7d0adc6c57764ab67da65081645a0015da4465e7dba7f4308ec5881b85b09f4e2065aab9652898303c652593770ee03e86cb06"
        },
        "payment": {
-         "sender":"1a4dd47666cb4010401e50ecf9dcd553bdc4c1b3c96ce028b14032cb7e9c154984",
+         "sender":"148pD3w44RtpDZ63RxzJoaCJYSUUEpfpFLyacw1qzAgLmo7",
          "amount":85000000,
          "txid":"a7o844001"
        }
@@ -181,11 +182,11 @@ Feature: Order Fulfillment
     When a payment arrives from x-forwarded-for 192.168.1.100
     """
     { "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495","nonce":2,
-      "signature":"9257a3df799c2fa416623407dc226e2518eb3847aa9d5a984ee9861db29b2d683e8e900aea49847605dd9e410e9b38c0face612a3e5da6e70bfa0d1dc8ad0e06"
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":2,
+      "signature":"8695eb40b1bcfa9a019f87f018cf0f753ed3f37407f28ca97093f6f99f8c8e2fbfffec3dcfa009d801369448e9ed9070d67064346453f2cd419792ff149ba00b"
     },
     "payment": {
-      "sender":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+      "sender":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
       "amount":400000000,
       "txid":"ab34cd56ef90"
       }
@@ -195,16 +196,16 @@ Feature: Order Fulfillment
     When a confirmation arrives from x-forwarded-for 192.168.1.100
     """
     { "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495","nonce":3,
-      "signature":"6c24e6d896e4146d0d03518d082dfea48a953ef0ab277ab1a0ae083a88d5a5430545bb5428aa5b76d91c744c2c3db35e0db6d34b39bde125045985f0bfb4fe00"
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":3,
+      "signature":"9ede42f17279ad27683c5bfcfca4f0eb28227bc411811629a9669c681985f255728bc81799546289591020ebb854c7564014249ed3f62cb8b8222334e8ff1f00"
       }, "confirmation": {"txid":"ab34cd56ef90"}
     }
     """
     When a confirmation arrives from x-forwarded-for 192.168.1.100
     """
     { "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495","nonce":4,
-      "signature":"36f0ac75b2dfbc7f99db4b5496d690c97c7940d924b58522b4d0f0025151552c1f691b4f4532835c5cf15ee2c6762d24288ae8f1cb2f22fb4160e628b54d1204"
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":4,
+      "signature":"5c8eb63b074d27fe2d75d7eb52613b177b4ca39ec2247d95b0ae71446638544e0ed4a952505e21913f74ea0bdf4396d5a2a60ca359b2889ceccf324c38f39d0b"
       }, "confirmation": {"txid":"a7o844001"}
     }
     """
@@ -213,9 +214,9 @@ Feature: Order Fulfillment
     When Customer #3 ["anon"] places order "anon0001" for 84 XTR, with memo
     """
     {
-       "address":"1a4dd47666cb4010401e50ecf9dcd553bdc4c1b3c96ce028b14032cb7e9c154984",
+       "address":"148pD3w44RtpDZ63RxzJoaCJYSUUEpfpFLyacw1qzAgLmo7",
        "order_id":"anon0001",
-       "signature":"86267d7373487427e0ea7af57ac2201e6b7d553faef34d701b3a2277fde54135fd5b7b073dfc8ba4a3b90589f3719c267c6b27957f18c4bfa31a31cc7f6a9a06"
+       "signature":"104baa540fa134d77dad4f1573238989be0d923f560b107e7938790d08e7cb73d3fa684865601b75b2cd6b747995327f194a0cfa96f7449cc449ed84f25f4a05"
     }
     """
     Then account for customer 3 has a current balance of 1 Tari
@@ -223,26 +224,26 @@ Feature: Order Fulfillment
     When Customer #1 ["alice"] places order "alice0002" for 3600 XTR, with memo
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "order_id":"alice0002",
-      "signature":"c28b548c3b45086fbfd0690c8201e96b1cd1bf7fedcaeb37eb51f0a418035c1dd924b9aa994ee39ad7a7672c6620153d5aef91b1c783f8135e6e17de8acdf206"
+      "signature":"9c613426a8dc256b378b63e083b3bd6d1b511fefc033975f543587955bec8b3fac51e7f871f99825cfa98b2e93c4dd5dc48af5a06cfb911b80fae287b78e5a0a"
     }
     """
     When a payment arrives from x-forwarded-for 192.168.1.100
     """
     { "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495","nonce":5,
-      "signature":"a4f9e365cb030a6b8d0055f958e63b2155539a13569b12780aa7bbb1107c336bb1399a6e5a6d71eadc843145f61134f0054c1ebad60325e913c9ad3764df860f"
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":5,
+      "signature":"46b8e6eab217a31d806eff207ca45d78b1e5c49d16516764c827d7d257fcb468e53e10fd1a1cfcdeec4baabfceaeb6ee6f97bf12503e8ee3309cdd8ed1742d05"
     }, "payment": {
-      "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d","amount":6042000000,"txid":"alicebigpayment"
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt","amount":6042000000,"txid":"alicebigpayment"
       }
     }
     """
     When a confirmation arrives from x-forwarded-for 192.168.1.100
     """
     { "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495","nonce":6,
-      "signature":"fc86a27e9d24c6d7294f9bc0c3231fbde136e79d690bf203d2516f195dca172c57ea79f51a32a09b2a113e1d57f50e4c70bb90bfe5b86b56242e433886298b09"
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":6,
+      "signature":"84b80c5f052c7b1d30613bc5ac7772b75d319252ed338c50b87cd77281780471384044b7f7ecfed1ec19c7dc1e49553f86121bfcd682d88926b588f9639e360a"
       }, "confirmation": {"txid":"alicebigpayment"}
     }
     """

--- a/e2e/tests/features/order_webhook_auth.feature
+++ b/e2e/tests/features/order_webhook_auth.feature
@@ -7,9 +7,9 @@ Feature: Order flow
     When Customer #1 ["alice"] places order "alice001" for 2500 XTR, with memo
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "order_id":"alice001",
-      "signature":"56e39d539f1865742b41993bdc771a2d0c16b35c83c57ca6173f8c1ced34140aeaf32bfdc0629e73f971344e7e45584cbbb778dc98564d0ec5c419e6f9ff5d06"
+      "signature":"601d2f88738b9aacdf75b62de9db23bb8d1aeb9fef8c7d127a05e9648729e64143adcee0a3d50665eb9c7817a0035ad9ac6248a8547bd6d5a4796b917bd57d09"
     }
     """
     Then Customer #1 has current orders worth 2500 XTR
@@ -20,7 +20,7 @@ Feature: Order flow
     When Customer #1 ["alice"] places order "alice002" for 2500 XTR, with memo
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "order_id":"alice002",
       "signature":"56e39d539f1865742b41993bdc771a2d0c16b35c83c57ca6173f8c1ced34140aeaf32bfdc0629e73f971344e7e45584cbbb778dc98564d0ec5c419e6f9ff5d06"
     }
@@ -33,7 +33,7 @@ Feature: Order flow
     When Customer #1 ["alice"] places order "alice001" for 2500 XTR, with memo
     """
     {
-      "address":"aa3c076152c1ae44ae86585eeba1d348badb845d1cab5ef12db98fafb4fea55d6c",
+      "address":"14sa5AzjqqrzfiyqGkajoNcFrqkCK7syB4rvNNL65f2PjLD",
       "order_id":"alice001",
       "signature":"56e39d539f1865742b41993bdc771a2d0c16b35c83c57ca6173f8c1ced34140aeaf32bfdc0629e73f971344e7e45584cbbb778dc98564d0ec5c419e6f9ff5d06"
     }

--- a/e2e/tests/features/orders.feature
+++ b/e2e/tests/features/orders.feature
@@ -15,7 +15,7 @@ Feature: Orders endpoint
     Then I receive a partial JSON response:
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "total_orders":165000000,
       "orders":[
         {"id":1,"order_id":"1","customer_id":"alice",
@@ -32,17 +32,17 @@ Feature: Orders endpoint
 
   Scenario: Standard user cannot access anyone else's orders
     When Alice authenticates with nonce = 1 and roles = "user"
-    When Alice GETs to "/api/orders/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Alice GETs to "/api/orders/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
 
   Scenario: User with ReadAll role can access another order set
     When Admin authenticates with nonce = 1 and roles = "user,read_all"
-    When Admin GETs to "/api/orders/b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d" with body
+    When Admin GETs to "/api/orders/14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "total_orders":165000000,
       "orders":[
         {"id":1,"order_id":"1","customer_id":"alice","total_price":100000000,"status":"New",
@@ -55,12 +55,12 @@ Feature: Orders endpoint
   Scenario: SuperAdmin role can access another account
     Given a super-admin user (Super)
     When Super authenticates with nonce = 1
-    When Super GETs to "/api/orders/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Super GETs to "/api/orders/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
     {
-      "address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+      "address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
       "total_orders":550000000,
       "orders":[
         {"order_id":"2","customer_id":"bob","total_price":200000000,"status":"New"},

--- a/e2e/tests/features/payment_history.feature
+++ b/e2e/tests/features/payment_history.feature
@@ -26,15 +26,15 @@ Feature: Payment history endpoint
     And I receive a partial JSON response:
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "total_payments":115000000,
       "payments":[
         {"txid":"alicepayment001",
-         "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+         "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
          "amount":15000000
         },
         {"txid":"alicepayment002",
-        "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+        "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
         "amount":100000000
         }
       ]
@@ -43,25 +43,25 @@ Feature: Payment history endpoint
 
   Scenario: Authenticated user cannot see another user's payment history
     When Alice authenticates with nonce = 1 and roles = "user"
-    When Alice GETs to "/api/payments/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Alice GETs to "/api/payments/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
 
   Scenario: User with ReadAll Role can see another user's payment history
     When Admin authenticates with nonce = 1 and roles = "user,read_all"
-    When Admin GETs to "/api/payments/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Admin GETs to "/api/payments/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 200 Ok response
     And I receive a partial JSON response:
     """
     {
-      "address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+      "address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
       "total_payments":550000000,
       "payments":[
         {"txid":"bobpayment001",
-         "sender":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+         "sender":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
          "amount":50000000
         },
         {"txid":"bobpayment002",
-        "sender":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+        "sender":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
         "amount":500000000
         }
       ]
@@ -71,20 +71,20 @@ Feature: Payment history endpoint
   Scenario: SuperAdmin can see another user's payment history
     Given a super-admin user (Super)
     When Super authenticates with nonce = 1
-    When Super GETs to "/api/payments/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Super GETs to "/api/payments/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
     {
-      "address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+      "address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
       "total_payments":550000000,
       "payments":[
         {"txid":"bobpayment001",
-         "sender":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+         "sender":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
          "amount":50000000
         },
         {"txid":"bobpayment002",
-        "sender":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+        "sender":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
         "amount":500000000
         }
       ]

--- a/e2e/tests/features/unfulfilled_orders.feature
+++ b/e2e/tests/features/unfulfilled_orders.feature
@@ -1,3 +1,4 @@
+@unfulfilled_orders
 Feature: The /api/unfulfilled_orders endpoint
   Background:
     Given a server configuration
@@ -6,32 +7,32 @@ Feature: The /api/unfulfilled_orders endpoint
     Given an authorized wallet with secret df158b8389c68aac01a91276b742d2527f951d3c7289e4ccdecfa0672947270e
     """
       {
-        "address": "c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "address": "14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
         "ip_address": "192.168.1.100"
       }
     """
     When Customer #1 ["alice"] places order "alice001" for 250 XTR, with memo
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "order_id":"alice001",
-      "signature":"a03f9c56f789a19167e964bc9c8cc060842a7664033afd5b9bc6cb2c57f38608d38b890012e4b9d54320054abab75b42635ccffbb98bf6b59e88d6e37185640b"
+      "signature":"601d2f88738b9aacdf75b62de9db23bb8d1aeb9fef8c7d127a05e9648729e64143adcee0a3d50665eb9c7817a0035ad9ac6248a8547bd6d5a4796b917bd57d09"
     }
     """
     When Customer #2 ["bob"] places order "bob001" for 999 XTR, with memo
     """
     {
-      "address":"680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+      "address":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
       "order_id":"bob001",
-      "signature":"d4e14f9465d0f5e7397c1726c87391408477ef87a9a2de32f99cdf48ceb27a0304a7767c7f1b87ddf3c14624385929e9d58ef0e0a7435766fa414de58d415b06"
+      "signature":"4c5f0fa0ffbf4064ee8a50a7033b83143209568581d28a0983059e46cbc7dd5e023813ea97fea351380c4528a73a2400ba929b65bd2dd538951dcc32ae3d9102"
     }
     """
     When Customer #1 ["alice"] places order "alice002" for 150 XTR, with memo
     """
     {
-      "address":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "order_id":"alice002",
-      "signature":"c2a797a6e690a98f7055c6e27e860d38607027cd9e05a18a5fc3f659222b5f1719ec1c66f82855f824e9009bb2f390196acaa9c8fe5b5620fe34a0484c98f203"
+      "signature":"28828b5ca8a693da33f4c98471295c6671c27f09053c101fefac21f96f280931398aaef0bd76b6df9c6c5a4cebb2b47865f1e4e34dc6bed0f0f4aa8da1827901"
     }
     """
 
@@ -49,13 +50,13 @@ Feature: The /api/unfulfilled_orders endpoint
     When a payment arrives from x-forwarded-for 192.168.1.100
     """
     {"payment": {
-      "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "amount":250000000,
       "txid":"payment001"
     },
     "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495","nonce":1,
-      "signature":"22cab0a461b2dcd0fd4f7ac688775b51e365bdde4f8b0f3d977a877e28151c43f3ee321ebcd8ec51b2fd41c022862ae507f4f93d37e77dadbfc3122718a4a10a"}
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":1,
+      "signature":"22382015f53740112c8f4455e0716bd20c915f10c230a245927913cf3297c03d07596b8c5ca2fbc5024edd311198ed7e066d6adbc6f8cd91ebc0cce1e1eb5006"}
     }
     """
     Then I receive a 200 Ok response with the message '"success":true'
@@ -64,9 +65,9 @@ Feature: The /api/unfulfilled_orders endpoint
     """
     { "confirmation": {"txid": "payment001"},
       "auth": {
-        "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
         "nonce":2,
-        "signature":"c2f727328c7387282b6e65c8fd0ffcd7a03355cb9046e3602991be9991a7860496ec9ecfa85c0463d37b6a3a2261e50964dfcd5127d41fa907c14448b2a4ce0b"
+        "signature":"fc1f12cb448b4c6184f11db5e28de911b6f53ca8120747d268405cd5c180c2212d61aa51bbfc00d26d0e2b8134eff6262fcdfedbf8309555bba1cb52bc424f04"
       }
     }
     """
@@ -80,22 +81,22 @@ Feature: The /api/unfulfilled_orders endpoint
   Scenario: Admin users with ReadAll role can access any unfulfilled orders
     Given some role assignments
     When Admin authenticates with nonce = 1 and roles = "read_all"
-    When Admin GETs to "/api/unfulfilled_orders/680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b" with body
+    When Admin GETs to "/api/unfulfilled_orders/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
     {
-      "address": "680ac255be13e424dd305c2ed93f58aee73670fadb97d733ad627efc9bb165510b",
+      "address": "14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
       "total_orders": 999000000,
       "orders": [ { "order_id": "bob001", "total_price": 999000000, "status": "New" } ]
     }
     """
-    When Admin GETs to "/api/unfulfilled_orders/b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d" with body
+    When Admin GETs to "/api/unfulfilled_orders/14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
     {
-      "address": "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "total_orders": 400000000,
       "orders": [ { "order_id": "alice001", "total_price": 250000000, "status": "New" }, { "order_id": "alice002", "total_price": 150000000, "status": "New" } ]
     }
@@ -104,13 +105,13 @@ Feature: The /api/unfulfilled_orders endpoint
     When a payment arrives from x-forwarded-for 192.168.1.100
     """
     {"payment": {
-      "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "amount":250000000,
       "txid":"payment001"
     },
     "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495","nonce":1,
-      "signature":"22cab0a461b2dcd0fd4f7ac688775b51e365bdde4f8b0f3d977a877e28151c43f3ee321ebcd8ec51b2fd41c022862ae507f4f93d37e77dadbfc3122718a4a10a"}
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":1,
+      "signature":"22382015f53740112c8f4455e0716bd20c915f10c230a245927913cf3297c03d07596b8c5ca2fbc5024edd311198ed7e066d6adbc6f8cd91ebc0cce1e1eb5006"}
     }
     """
     Then I receive a 200 Ok response with the message '"success":true'
@@ -119,18 +120,18 @@ Feature: The /api/unfulfilled_orders endpoint
     """
     { "confirmation": {"txid": "payment001"},
       "auth": {
-        "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
         "nonce":2,
-        "signature":"c2f727328c7387282b6e65c8fd0ffcd7a03355cb9046e3602991be9991a7860496ec9ecfa85c0463d37b6a3a2261e50964dfcd5127d41fa907c14448b2a4ce0b"
+        "signature":"fc1f12cb448b4c6184f11db5e28de911b6f53ca8120747d268405cd5c180c2212d61aa51bbfc00d26d0e2b8134eff6262fcdfedbf8309555bba1cb52bc424f04"
       }
     }
     """
-    When Admin GETs to "/api/unfulfilled_orders/b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d" with body
+    When Admin GETs to "/api/unfulfilled_orders/14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
     {
-      "address": "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "address": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "total_orders": 150000000,
       "orders": [ { "order_id": "alice002", "total_price": 150000000, "status": "New" } ]
     }

--- a/e2e/tests/features/wallet_auth.feature
+++ b/e2e/tests/features/wallet_auth.feature
@@ -1,3 +1,4 @@
+@wallet_auth
 Feature: Wallet Authorization
   Background:
     Given a server configuration
@@ -7,7 +8,7 @@ Feature: Wallet Authorization
     Given an authorized wallet with secret df158b8389c68aac01a91276b742d2527f951d3c7289e4ccdecfa0672947270e
     """
       {
-        "address": "c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "address": "14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
         "ip_address": "192.168.1.100"
       }
     """
@@ -16,12 +17,12 @@ Feature: Wallet Authorization
     When a payment arrives from x-forwarded-for 1.2.3.4
     """
     {"payment": {
-      "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "amount":2500000000,
       "txid":"payment001"
     },
     "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
       "nonce":1,
       "signature":"06d0cd5b00172990300481ea509de8c2e184595ed32b587b701aff7134279023b7dfde81542b6b383ff9594d6f4f0dea30347d110bbb496f5041738865f5e80c"
     }}
@@ -32,14 +33,14 @@ Feature: Wallet Authorization
     When a payment arrives from x-forwarded-for 192.168.1.100
     """
     {"payment": {
-      "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "amount":2500000000,
       "txid":"payment001"
     },
     "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
       "nonce":1,
-      "signature":"06d0cd5b00172990300481ea509de8c2e184595ed32b587b701aff7134279023b7dfde81542b6b383ff9594d6f4f0dea30347d110bbb496f5041738865f5e80c"
+      "signature":"f059d52b25d3f1387b8a9becca8775c1ff9a62b7293ba3791f78e77ac63a786e3c02534529809d4dd4ae8ccafeae28c6b2e4a105baf2fa9ebad44776978d4b02"
     }}
     """
     Then I receive a 200 Ok response with the message '"success":true'
@@ -48,14 +49,14 @@ Feature: Wallet Authorization
     When a payment arrives from forwarded 192.168.1.100
     """
     {"payment": {
-      "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "amount":2500000000,
       "txid":"payment001"
     },
     "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
       "nonce":1,
-      "signature":"06d0cd5b00172990300481ea509de8c2e184595ed32b587b701aff7134279023b7dfde81542b6b383ff9594d6f4f0dea30347d110bbb496f5041738865f5e80c"
+      "signature":"f059d52b25d3f1387b8a9becca8775c1ff9a62b7293ba3791f78e77ac63a786e3c02534529809d4dd4ae8ccafeae28c6b2e4a105baf2fa9ebad44776978d4b02"
     }}
     """
     Then I receive a 200 Ok response with the message '"success":true'
@@ -63,8 +64,8 @@ Feature: Wallet Authorization
   Scenario: Wallet Authorization from correct IP address has incorrect signature
     When a payment arrives from x-forwarded-for 192.168.1.100
     """
-    { "payment": { "sender": "b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d", "amount": 500000000, "txid": "payment001", "order_id": "order001" },
-      "auth": { "address": "c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495", "nonce": 1,
+    { "payment": { "sender": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt", "amount": 500000000, "txid": "payment001", "order_id": "order001" },
+      "auth": { "address": "14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG", "nonce": 1,
       "signature": "bad570a3da2b8d233d4d5e12e54d71b8b0a5be8cf56a878fb078f3757a07417fd64d61ae002276e96893d47d725085552bc15babb2488836af39a408a07c5200" } }
     """
     Then I receive a 401 Ok response with the message ''
@@ -73,12 +74,12 @@ Feature: Wallet Authorization
     When a payment arrives from forwarded 192.168.1.100
     """
     {"payment": {
-      "sender":"b8971598a865b25b6508d4ba154db228e044f367bd9a1ef50dd4051db42b63143d",
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
       "amount":99999999999,
       "txid":"payment001"
     },
     "auth": {
-      "address":"c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
       "nonce":1,
       "signature":"06d0cd5b00172990300481ea509de8c2e184595ed32b587b701aff7134279023b7dfde81542b6b383ff9594d6f4f0dea30347d110bbb496f5041738865f5e80c"
     }}

--- a/e2e/tests/features/wallet_management.feature
+++ b/e2e/tests/features/wallet_management.feature
@@ -6,7 +6,7 @@ Feature: Wallet Management
     Given an authorized wallet with secret df158b8389c68aac01a91276b742d2527f951d3c7289e4ccdecfa0672947270e
     """
       {
-        "address": "c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "address": "14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
         "ip_address": "192.168.1.100"
       }
     """
@@ -16,7 +16,7 @@ Feature: Wallet Management
     Then I receive a 200 OK response
     And I receive a partial JSON response:
     """
-    ["c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495"]
+    ["14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG"]
     """
 
   Scenario: SuperAdmin can add an authorized wallet
@@ -25,7 +25,7 @@ Feature: Wallet Management
     When Super POSTs to "/api/wallets" with body
     """
     {
-      "address": "7a83ef47b358bead8f2e595814146784014002a6aa124c9b31134e489d27617309",
+      "address": "14k2QoJQUdzwi1rGdTUBjhq4sELavZ3ikEuja8R5TPrq452",
       "ip_address": "100.50.60.70",
       "initial_nonce": 1
     }
@@ -36,7 +36,7 @@ Feature: Wallet Management
     When User POSTs to "/api/wallets" with body
     """
     {
-      "address": "7a83ef47b358bead8f2e595814146784014002a6aa124c9b31134e489d27617309",
+      "address": "14k2QoJQUdzwi1rGdTUBjhq4sELavZ3ikEuja8R5TPrq452",
       "ip_address": "100.50.60.70",
       "initial_nonce": 1
     }
@@ -48,7 +48,7 @@ Feature: Wallet Management
     When Alice POSTs to "/api/wallets" with body
     """
     {
-      "address": "7a83ef47b358bead8f2e595814146784014002a6aa124c9b31134e489d27617309",
+      "address": "14k2QoJQUdzwi1rGdTUBjhq4sELavZ3ikEuja8R5TPrq452",
       "ip_address": "100.50.60.70",
       "initial_nonce": 1
     }
@@ -60,7 +60,7 @@ Feature: Wallet Management
     When Admin POSTs to "/api/wallets" with body
     """
     {
-      "address": "7a83ef47b358bead8f2e595814146784014002a6aa124c9b31134e489d27617309",
+      "address": "14k2QoJQUdzwi1rGdTUBjhq4sELavZ3ikEuja8R5TPrq452",
       "ip_address": "100.50.60.70",
       "initial_nonce": 1
     }
@@ -72,7 +72,7 @@ Feature: Wallet Management
     When Admin POSTs to "/api/wallets" with body
     """
     {
-      "address": "7a83ef47b358bead8f2e595814146784014002a6aa124c9b31134e489d27617309",
+      "address": "14k2QoJQUdzwi1rGdTUBjhq4sELavZ3ikEuja8R5TPrq452",
       "ip_address": "100.50.60.70",
       "initial_nonce": 1
     }
@@ -88,7 +88,7 @@ Feature: Wallet Management
     """
     [
       {
-        "address": "c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "address": "14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
         "ip_address": "192.168.1.100",
         "last_nonce": 0
       }
@@ -112,7 +112,7 @@ Feature: Wallet Management
     """
     [
       {
-        "address": "c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495",
+        "address": "14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
         "ip_address": "192.168.1.100",
         "last_nonce": 0
       }
@@ -122,7 +122,7 @@ Feature: Wallet Management
   Scenario: SuperAdmin user can remove an authorized addresses
     Given a super-admin user (Super)
     When Super authenticates with nonce = 1
-    When Super DELETEs to "/api/wallets/c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495" with body
+    When Super DELETEs to "/api/wallets/14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG" with body
     Then I receive a 200 OK response
     When User GETs to "/wallet/send_to" with body
     Then I receive a 200 OK response
@@ -132,22 +132,22 @@ Feature: Wallet Management
     """
 
   Scenario: Unauthenticated user cannot remove an authorized addresses
-    When User DELETEs to "/api/wallets/c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495" with body
+    When User DELETEs to "/api/wallets/14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG" with body
     Then I receive a 401 Unauthenticated response with the message 'An error occurred, no cookie containing a jwt was found in the request.'
 
   Scenario: Normal user cannot remove an authorized addresses
     When Alice authenticates with nonce = 1 and roles = "user"
-    When Alice DELETEs to "/api/wallets/c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495" with body
+    When Alice DELETEs to "/api/wallets/14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG" with body
     Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
 
   Scenario: ReadAll admin cannot remove an authorized addresses
     When Admin authenticates with nonce = 1 and roles = "read_all"
-    When Admin DELETEs to "/api/wallets/c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495" with body
+    When Admin DELETEs to "/api/wallets/14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG" with body
     Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
 
   Scenario: Write admin cannot remove an authorized addresses
     When Admin authenticates with nonce = 1 and roles = "write"
-    When Admin DELETEs to "/api/wallets/c009584dac6ad9ca0964e3dc93892c607ca37e049b4c30637fa477d0d601174495" with body
+    When Admin DELETEs to "/api/wallets/14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG" with body
     Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
 
 

--- a/shopify_tools/Cargo.toml
+++ b/shopify_tools/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "shopify_tools"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-tpg_common = { version = "0.2.1", path = "../tpg_common" }
+tpg_common = { version = "0.3.0", path = "../tpg_common" }
 chrono = { version = "0.4.31", features = ["serde"] }
 graphql-parser = "0.4.0"
 log = "0.4.21"

--- a/tari_payment_engine/Cargo.toml
+++ b/tari_payment_engine/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "tari_payment_engine"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "Database backend for Tari payment gateway"
 
 [dependencies]
-tpg_common = { version = "0.2.1", path = "../tpg_common" }
+tpg_common = { version = "0.3.0", path = "../tpg_common" }
+
 blake2 = "0.10.6"
 chrono = { version = "0.4.31", features = ["serde"] }
 dotenvy = {  version = "0.15.0", optional = true }
@@ -13,15 +14,15 @@ env_logger = {  version = "0.11.3", optional = true }
 futures-util = "0.3.30"
 log = "0.4.17"
 rand = {  version = "0.8.5" }
+regex = "1.10.3"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 sqlx = { version = "0.7.3", features = ["runtime-tokio", "chrono"] }
+tari_common = {version = "1.3.1-pre.1", git = "https://github.com/tari-project/tari.git", package = "tari_common", tag = "v1.3.1-pre.1" }
+tari_common_types = {version = "1.3.1-pre.1", git = "https://github.com/tari-project/tari.git", package = "tari_common_types", tag = "v1.3.1-pre.1" }
+tari_crypto = { version = "0.20.1", default-features = false }
 thiserror = "1.0.32"
 tokio = { version = "1.20.1", features = ["full"] }
-regex = "1.10.3"
-tari_common = "1.0.0-rc.5"
-tari_common_types = "1.0.0-pre.10"
-tari_crypto = { version = "0.20.1", default-features = false }
 
 [features]
 default = ["sqlite"]

--- a/tari_payment_engine/src/db_types.rs
+++ b/tari_payment_engine/src/db_types.rs
@@ -14,7 +14,7 @@ use tpg_common::MicroTari;
 
 use crate::{
     helpers::{extract_and_verify_memo_signature, MemoSignature, MemoSignatureError},
-    tpe_api::order_objects::{address_to_hex, str_to_address},
+    tpe_api::order_objects::{address_to_base58, str_to_address},
 };
 
 //--------------------------------------     PublicKey       ---------------------------------------------------------
@@ -39,7 +39,7 @@ impl<S: Into<String>> From<S> for PublicKey {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SerializedTariAddress(
-    #[serde(serialize_with = "address_to_hex", deserialize_with = "str_to_address")] TariAddress,
+    #[serde(serialize_with = "address_to_base58", deserialize_with = "str_to_address")] TariAddress,
 );
 
 impl SerializedTariAddress {
@@ -51,8 +51,13 @@ impl SerializedTariAddress {
         &self.0
     }
 
+    #[deprecated(since = "0.3.0", note = "Use as_base58 instead")]
     pub fn as_hex(&self) -> String {
         self.0.to_hex()
+    }
+
+    pub fn as_base58(&self) -> String {
+        self.0.to_base58()
     }
 }
 
@@ -92,7 +97,7 @@ impl From<&TariAddress> for SerializedTariAddress {
 
 impl Display for SerializedTariAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_hex())
+        write!(f, "{}", self.as_base58())
     }
 }
 
@@ -127,7 +132,7 @@ impl Eq for SerializedTariAddress {}
 
 impl Hash for SerializedTariAddress {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_hex().hash(state);
+        self.as_base58().hash(state);
     }
 }
 
@@ -577,14 +582,14 @@ mod test {
     #[test]
     fn extract_order_id() {
         let mut payment = NewPayment::new(
-            TariAddress::from_str("a8d523755de41b9c14de709ca59d52bc1772658258962ef5bbefa8c59082e54733").unwrap(),
+            TariAddress::from_str("14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY").unwrap(),
             MicroTari::from_tari(100),
             "txid111111".to_string(),
         );
         payment.with_memo(json!({
-            "address": "a8d523755de41b9c14de709ca59d52bc1772658258962ef5bbefa8c59082e54733",
+            "address": "14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY",
             "order_id": "oid554432",
-            "signature": "2421e3c98522d7c5518f55ddb39f759ee9051dde8060679d48f257994372fb214e9024917a5befacb132fc9979527ff92daa2c5d42062b8a507dc4e3b6954c05"
+            "signature": "74236918f5815383ad7a889fa2c26037418b217f983575b5b5cfde21c7bcf3094ca6ff09c43fca8d4040a38e60b57fea622d5919979fae4ccfea93883df6bd00"
             }).to_string()
         );
         let result = payment.try_extract_order_id();

--- a/tari_payment_engine/src/helpers/memo_signature.rs
+++ b/tari_payment_engine/src/helpers/memo_signature.rs
@@ -88,7 +88,7 @@ impl MemoSignature {
 
     pub fn is_valid(&self) -> bool {
         let message = self.message();
-        let pubkey = self.address.as_address().public_key();
+        let pubkey = self.address.as_address().comms_public_key();
         self.signature.verify(pubkey, message)
     }
 
@@ -98,7 +98,7 @@ impl MemoSignature {
 }
 
 pub fn signature_message(address: &SerializedTariAddress, order_id: &str) -> String {
-    let addr = address.as_address().to_hex();
+    let addr = address.as_address().to_base58();
     format!("{addr}:{order_id}")
 }
 
@@ -170,17 +170,12 @@ mod test {
 
     #[test]
     fn create_memo_signature() {
-        let address = "a8d523755de41b9c14de709ca59d52bc1772658258962ef5bbefa8c59082e54733"
-            .parse()
-            .expect("Failed to parse TariAddress");
+        let address = "14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY".parse().expect("Failed to parse TariAddress");
         let sig =
             MemoSignature::create(address, "oid554432".into(), &secret_key()).expect("Failed to create memo signature");
         let msg = signature_message(&sig.address, &sig.order_id);
-        assert_eq!(msg, "a8d523755de41b9c14de709ca59d52bc1772658258962ef5bbefa8c59082e54733:oid554432");
-        assert_eq!(
-            sig.address.as_address().to_hex(),
-            "a8d523755de41b9c14de709ca59d52bc1772658258962ef5bbefa8c59082e54733"
-        );
+        assert_eq!(msg, "14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY:oid554432");
+        assert_eq!(sig.address.as_address().to_base58(), "14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY");
         assert_eq!(sig.order_id, "oid554432");
         assert!(sig.is_valid());
     }
@@ -188,15 +183,12 @@ mod test {
     #[test]
     fn verify_from_json() {
         let json = r#"{
-          "address": "a8d523755de41b9c14de709ca59d52bc1772658258962ef5bbefa8c59082e54733",
+          "address": "14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY",
           "order_id": "oid554432",
-          "signature": "2421e3c98522d7c5518f55ddb39f759ee9051dde8060679d48f257994372fb214e9024917a5befacb132fc9979527ff92daa2c5d42062b8a507dc4e3b6954c05"
+          "signature": "74236918f5815383ad7a889fa2c26037418b217f983575b5b5cfde21c7bcf3094ca6ff09c43fca8d4040a38e60b57fea622d5919979fae4ccfea93883df6bd00"
         }"#;
         let sig = serde_json::from_str::<MemoSignature>(json).expect("Failed to deserialize memo signature");
-        assert_eq!(
-            sig.address.as_address().to_hex(),
-            "a8d523755de41b9c14de709ca59d52bc1772658258962ef5bbefa8c59082e54733"
-        );
+        assert_eq!(sig.address.as_address().to_base58(), "14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY");
         assert_eq!(sig.order_id, "oid554432");
         assert!(sig.is_valid());
     }

--- a/tari_payment_engine/src/helpers/wallet_signature.rs
+++ b/tari_payment_engine/src/helpers/wallet_signature.rs
@@ -71,7 +71,7 @@ impl WalletSignature {
         let Ok(message) = Self::signature_message(&self.address, self.nonce, payload) else {
             return false;
         };
-        let pubkey = self.address.as_address().public_key();
+        let pubkey = self.address.as_address().comms_public_key();
         self.signature.verify(pubkey, message)
     }
 

--- a/tari_payment_engine/src/sqlite/db/user_accounts.rs
+++ b/tari_payment_engine/src/sqlite/db/user_accounts.rs
@@ -147,7 +147,7 @@ pub async fn user_account_for_address(
     address: &TariAddress,
     conn: &mut SqliteConnection,
 ) -> Result<Option<UserAccount>, AccountApiError> {
-    let pk = address.to_hex();
+    let pk = address.to_base58();
     let result = sqlx::query_as!(
         UserAccount,
         r#"
@@ -179,7 +179,7 @@ pub async fn fetch_account_ids_for_address(
     addr: &TariAddress,
     conn: &mut SqliteConnection,
 ) -> Result<Vec<i64>, AccountApiError> {
-    let addr = addr.to_hex();
+    let addr = addr.to_base58();
     let ids = sqlx::query!(
         "SELECT user_account_id FROM user_account_address WHERE address = $1 ORDER BY created_at DESC",
         addr
@@ -201,7 +201,7 @@ pub async fn fetch_accounts_for_address(
     oldest_first: bool,
     conn: &mut SqliteConnection,
 ) -> Result<Vec<UserAccount>, AccountApiError> {
-    let addr = addr.to_hex();
+    let addr = addr.to_base58();
     let q = format!(
         "SELECT * FROM user_accounts WHERE id in (SELECT user_account_id from user_account_address WHERE address = \
          $1) ORDER BY created_at {}",
@@ -256,7 +256,7 @@ pub async fn link_accounts(
         debug!("🧑️ Linked user account #{acc_id} to customer_id {cid}");
     };
     if let Some(addr) = address {
-        let addr = addr.to_hex();
+        let addr = addr.to_base58();
         let result =
             sqlx::query!("INSERT INTO user_account_address (user_account_id, address) VALUES ($1, $2)", acc_id, addr,)
                 .execute(tx)
@@ -499,7 +499,7 @@ pub(crate) async fn addresses(
     conn: &mut SqliteConnection,
 ) -> Result<Vec<TariAddress>, AccountApiError> {
     let rows = with_pagination("SELECT address FROM user_account_address", pagination, conn).await?;
-    let addresses = rows.into_iter().filter_map(|r| TariAddress::from_hex(r.get("address")).ok()).collect();
+    let addresses = rows.into_iter().filter_map(|r| TariAddress::from_base58(r.get("address")).ok()).collect();
     Ok(addresses)
 }
 

--- a/tari_payment_engine/src/sqlite/db/wallet_auth.rs
+++ b/tari_payment_engine/src/sqlite/db/wallet_auth.rs
@@ -12,7 +12,7 @@ pub async fn fetch_wallet_info_for_address(
     address: &TariAddress,
     conn: &mut SqliteConnection,
 ) -> Result<WalletInfo, WalletAuthApiError> {
-    let address = address.to_hex();
+    let address = address.to_base58();
     sqlx::query(r#"SELECT * FROM wallet_auth WHERE address = ?"#)
         .bind(address)
         .fetch_optional(conn)
@@ -31,7 +31,7 @@ pub async fn update_wallet_nonce(
     new_nonce: i64,
     conn: &mut SqliteConnection,
 ) -> Result<(), WalletAuthApiError> {
-    let address = address.to_hex();
+    let address = address.to_base58();
     let result = query!(r#"UPDATE wallet_auth SET last_nonce = ? WHERE address = ?"#, new_nonce, address)
         .execute(conn)
         .await
@@ -56,7 +56,7 @@ pub(crate) async fn register_wallet(
     info: NewWalletInfo,
     conn: &mut SqliteConnection,
 ) -> Result<(), WalletManagementError> {
-    let address = info.address.as_hex();
+    let address = info.address.as_base58();
     let ip_address = info.ip_address.to_string();
     let nonce = info.initial_nonce.unwrap_or(0);
     let result = query!(
@@ -77,7 +77,7 @@ pub(crate) async fn deregister_wallet(
     address: &TariAddress,
     conn: &mut SqliteConnection,
 ) -> Result<(), WalletManagementError> {
-    let address = address.to_hex();
+    let address = address.to_base58();
     let result = query!(r#"DELETE FROM wallet_auth WHERE address = ?"#, address).execute(conn).await?;
     if result.rows_affected() == 0 {
         return Err(WalletManagementError::DatabaseError("Wallet not found".to_string()));
@@ -97,7 +97,7 @@ pub(crate) async fn fetch_authorized_wallets(
                 .get::<&str, _>("ip_address")
                 .parse::<IpAddr>()
                 .map_err(|e| WalletManagementError::DatabaseError(format!("Invalid IP address. {e}")))?;
-            let address = TariAddress::from_hex(row.get("address"))
+            let address = TariAddress::from_base58(row.get("address"))
                 .map_err(|e| WalletManagementError::DatabaseError(format!("Invalid TariAddress. {e}")))?;
             let address = SerializedTariAddress::from(address);
             let last_nonce = row.get("last_nonce");

--- a/tari_payment_engine/src/sqlite/sqlite_impl.rs
+++ b/tari_payment_engine/src/sqlite/sqlite_impl.rs
@@ -669,10 +669,10 @@ impl AccountManagement for SqliteDatabase {
 
     async fn fetch_user_account_for_address(
         &self,
-        pubkey: &TariAddress,
+        address: &TariAddress,
     ) -> Result<Option<UserAccount>, AccountApiError> {
         let mut conn = self.pool.acquire().await?;
-        user_accounts::user_account_for_address(pubkey, &mut conn).await
+        user_accounts::user_account_for_address(address, &mut conn).await
     }
 
     async fn fetch_orders_for_account(&self, account_id: i64) -> Result<Vec<Order>, AccountApiError> {
@@ -781,7 +781,7 @@ impl AuthManagement for SqliteDatabase {
         let mut tx = self.pool.begin().await.map_err(|e| AuthApiError::DatabaseError(e.to_string()))?;
         auth::assign_roles(address, roles, &mut tx).await?;
         tx.commit().await.map_err(|e| AuthApiError::DatabaseError(e.to_string()))?;
-        debug!("🔑️ Roles {roles:?} assigned to {}", address.to_hex());
+        debug!("🔑️ Roles {roles:?} assigned to {}", address.to_base58());
         Ok(())
     }
 

--- a/tari_payment_engine/src/tpe_api/order_objects.rs
+++ b/tari_payment_engine/src/tpe_api/order_objects.rs
@@ -18,11 +18,20 @@ pub struct OrderResult {
     pub orders: Vec<Order>,
 }
 
+#[deprecated(since = "0.3.0", note = "Use address_to_base58 instead")]
 pub fn address_to_hex<S>(address: &TariAddress, serializer: S) -> Result<S::Ok, S::Error>
 where S: serde::Serializer {
     serializer.serialize_str(&address.to_hex())
 }
 
+pub fn address_to_base58<S>(address: &TariAddress, serializer: S) -> Result<S::Ok, S::Error>
+where S: serde::Serializer {
+    serializer.serialize_str(&address.to_base58())
+}
+
+/// Deserialize a TariAddress from a string.
+///
+/// Emoji ID, hex, and base58 addresses are supported.
 pub fn str_to_address<'de, D>(deserializer: D) -> Result<TariAddress, D::Error>
 where D: serde::Deserializer<'de> {
     let s = String::deserialize(deserializer)?;

--- a/tari_payment_engine/src/tpe_api/wallet_api.rs
+++ b/tari_payment_engine/src/tpe_api/wallet_api.rs
@@ -56,7 +56,7 @@ where B: WalletAuth
         if !sig.is_valid(payload) {
             return Err(WalletAuthApiError::InvalidSignature);
         }
-        trace!("Wallet signature for {} is valid", sig.address.as_hex());
+        trace!("Wallet signature for {} is valid", sig.address.as_base58());
         let address = sig.address.as_address();
         let wallet_info = self.db.get_wallet_info(address).await?;
         if wallet_info.address != sig.address {

--- a/tari_payment_engine/tests/burst_transfers.rs
+++ b/tari_payment_engine/tests/burst_transfers.rs
@@ -28,8 +28,8 @@ fn burst_transfers() {
         prepare_test_env(url).await;
         let db = SqliteDatabase::new_with_url(url, 5).await.expect("Error creating database");
         let api = OrderFlowApi::new(db, EventProducers::default());
-        let pk = TariAddress::from_str("6829578d62ddcba2191178287307a07dc8244af92b6bebc2b83ee41a40880e4897")
-            .expect("Not a valid Tari address");
+        let pk =
+            TariAddress::from_str("14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY").expect("Not a valid Tari address");
 
         let mut timer = tokio::time::interval(delay);
         for i in 0..NUM_TRANSFERS {

--- a/tari_payment_server/Cargo.toml
+++ b/tari_payment_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_payment_server"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,32 +12,32 @@ shopify = ["shopify_tools"]
 
 
 [dependencies]
-shopify_tools = { version = "0.2.1", path = "../shopify_tools", optional = true }
-tpg_common = { version = "0.2.1", path = "../tpg_common" }
-paste = "1.0.14"
-tari-jwt = {  version = "0.1.0", git = "https://github.com/tari-project/tari-jwt.git", branch = "main" }
-tari_payment_engine = { version = "0.2.1", path = "../tari_payment_engine" }
+shopify_tools = { version = "0.3.0", path = "../shopify_tools", optional = true }
+tpg_common = { version = "0.3.0", path = "../tpg_common" }
+tari_payment_engine = { version = "0.3.0", path = "../tari_payment_engine" }
 
 actix-jwt-auth-middleware = { version = "0.5.0", git = "https://github.com/cjs77/actix-jwt-auth-middleware.git", branch = "master" }
 actix-http = "3.8.0"
 actix-web = "4.0.0-beta.8"
+base64 = "0.13.1"
+bytes = "1.6.0"
 chrono = { version = "0.4.31", features = ["serde"] }
 dotenvy = "0.15.0"
 env_logger = "0.11.3"
+futures = "0.3.30"
+hmac = "0.12.1"
 log = "0.4.17"
+paste = "1.0.14"
 rand = "0.8.4"
+regex = "1.10.4"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
-tari_common_types = "1.0.0-pre.10"
+sha2 = "0.10.8"
+tari_common_types = {version = "1.3.1-pre.1", git = "https://github.com/tari-project/tari.git", package = "tari_common_types", tag = "v1.3.1-pre.1" }
+tari-jwt = {  version = "0.1.0", git = "https://github.com/tari-project/tari-jwt.git", branch = "main" }
 tempfile = "3.10.1"
 thiserror = "1.0.32"
 tokio = { version = "1.20.1", features = ["full"] }
-futures = "0.3.30"
-regex = "1.10.4"
-sha2 = "0.10.8"
-base64 = "0.13.1"
-hmac = "0.12.1"
-bytes = "1.6.0"
 
 [dev-dependencies]
 anyhow = "1.0.81"

--- a/tari_payment_server/src/auth.rs
+++ b/tari_payment_server/src/auth.rs
@@ -53,7 +53,7 @@ pub fn check_login_token_signature<S: AsRef<str>>(token: S) -> Result<LoginToken
         UntrustedToken::new(token.as_ref()).map_err(|e| AuthError::PoorlyFormattedToken(format!("{e:?}")))?;
     let claims: Claims<LoginToken> =
         untrusted_token.deserialize_claims_unchecked().map_err(|e| AuthError::ValidationError(format!("{e:?}")))?;
-    let pubkey = claims.custom.address.public_key();
+    let pubkey = claims.custom.address.comms_public_key();
     let verifying_key = Ristretto256VerifyingKey(pubkey.clone());
     let (header, claims) = Ristretto256
         .validator(&verifying_key)

--- a/tari_payment_server/src/endpoint_tests/accounts.rs
+++ b/tari_payment_server/src/endpoint_tests/accounts.rs
@@ -29,7 +29,7 @@ async fn fetch_my_account_no_headers() {
 #[actix_web::test]
 async fn fetch_my_account_expired_token() {
     let claims = JwtClaims {
-        address: TariAddress::from_hex("b4db54f75421a02b0d0056fb7203df23c742b25e41283976bdaa7fe63de1ad234d").unwrap(),
+        address: TariAddress::from_base58("14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2").unwrap(),
         roles: vec![Role::User],
     };
     let expired = Utc::now() - Days::new(1);
@@ -42,7 +42,7 @@ async fn fetch_my_account_expired_token() {
 #[actix_web::test]
 async fn fetch_my_account_valid_token() {
     let claims = JwtClaims {
-        address: TariAddress::from_hex("b4db54f75421a02b0d0056fb7203df23c742b25e41283976bdaa7fe63de1ad234d").unwrap(),
+        address: TariAddress::from_base58("14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2").unwrap(),
         roles: vec![Role::User],
     };
     let token = issue_token(claims, Utc::now() + Days::new(1));
@@ -57,14 +57,13 @@ async fn fetch_my_account_valid_token() {
 #[actix_web::test]
 async fn fetch_account_from_admin() {
     let claims = JwtClaims {
-        address: TariAddress::from_hex("b4db54f75421a02b0d0056fb7203df23c742b25e41283976bdaa7fe63de1ad234d").unwrap(),
+        address: TariAddress::from_base58("14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2").unwrap(),
         roles: vec![Role::ReadAll],
     };
     let token = issue_token(claims, Utc::now() + Days::new(1));
-    let (status, body) =
-        get_request(&token, "/account/fc899cd4395e86e9409fc892f5b0a064373a4300321650e205e446374f6b8f073d", configure)
-            .await
-            .expect("Failed to make request");
+    let (status, body) = get_request(&token, "/account/14hdm1NzAtAvzrtoLHp5ov925CLSbtkDrrWy7avU8QNguBL", configure)
+        .await
+        .expect("Failed to make request");
     assert_eq!(status, StatusCode::OK);
     let json = r#"
     {"id":1,"created_at":"2024-03-01T10:30:00Z","updated_at":"2024-03-01T10:30:00Z","total_received":1000000,"current_pending":0,"current_balance":1000000,"total_orders":0,"current_orders":0}
@@ -75,21 +74,20 @@ async fn fetch_account_from_admin() {
 #[actix_web::test]
 async fn fetch_account_from_user() {
     let claims = JwtClaims {
-        address: TariAddress::from_hex("b4db54f75421a02b0d0056fb7203df23c742b25e41283976bdaa7fe63de1ad234d").unwrap(),
+        address: TariAddress::from_base58("14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2").unwrap(),
         roles: vec![Role::User],
     };
     let token = issue_token(claims, Utc::now() + Days::new(1));
-    let err =
-        get_request(&token, "/account/fc899cd4395e86e9409fc892f5b0a064373a4300321650e205e446374f6b8f073d", configure)
-            .await
-            .expect_err("Request should have failed");
+    let err = get_request(&token, "/account/14hdm1NzAtAvzrtoLHp5ov925CLSbtkDrrWy7avU8QNguBL", configure)
+        .await
+        .expect_err("Request should have failed");
     assert_eq!(err, "Insufficient permissions.");
 }
 
 #[actix_web::test]
 async fn fetch_account_from_users_own_address() {
     let claims = JwtClaims {
-        address: TariAddress::from_hex("b4db54f75421a02b0d0056fb7203df23c742b25e41283976bdaa7fe63de1ad234d").unwrap(),
+        address: TariAddress::from_base58("14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2").unwrap(),
         roles: vec![Role::User],
     };
     let token = issue_token(claims, Utc::now() + Days::new(1));

--- a/tari_payment_server/src/endpoint_tests/auth.rs
+++ b/tari_payment_server/src/endpoint_tests/auth.rs
@@ -52,17 +52,17 @@ async fn login_with_invalid_signature() {
 
 #[actix_web::test]
 async fn login_with_valid_token() {
-    let token = "eyJhbGciOiJSaXN0cmV0dG8yNTYiLCJ0eXAiOiJKV1QifQ.eyJhZGRyZXNzIjp7Im5ldHdvcmsiOiJtYWlubmV0IiwicHVibGljX2tleSI6IjEyYTI1MDRhNzhmMDg5MzBjMmQzMzU3MDhmYWU4MDY5NmIyMTdkMjNiZDJkNDczZTEyN2Q4ZjVhMzBlMjgxNjUifSwibm9uY2UiOjE3MTE0NDg2NDksImRlc2lyZWRfcm9sZXMiOlsidXNlciIsIndyaXRlIl19.gm2Z6FxNyMmLT_dcEGu_iH9_wBm029OY_eqw__hZ0yXpa0ccVeBbF1lTfYU5xEhmGtQXtwhOjC8l2SUm9QB8CQ";
+    let token = "eyJhbGciOiJSaXN0cmV0dG8yNTYiLCJ0eXAiOiJKV1QifQ.eyJhZGRyZXNzIjp7IlNpbmdsZSI6eyJuZXR3b3JrIjoibWFpbm5ldCIsImZlYXR1cmVzIjozLCJwdWJsaWNfc3BlbmRfa2V5IjoiYzA4ZjEwOGUzZTQ1ZmZmNjhkYmNmOGJkYTlhMzZjOGUxYTEyMzA5NTlkNzdkNTdiM2RlNmEwYTVmNTE5NjM1NCJ9fSwibm9uY2UiOjE3MjUyOTg0NDUsImRlc2lyZWRfcm9sZXMiOlsidXNlciIsIndyaXRlIl19.Go2laadEE96JkkbO5ZN7Qcf3aULX0fRdph7gkIFudxRdg_jXCUxSmr5p2UKhuMqdD9K16_Zk8Xel1DFSqmrvBQ";
     let (status, s, config) = post_request(token, Ok(())).await;
     let token = validate_token(&s, &config.jwt_verification_key).unwrap();
     assert!(status.is_success());
-    assert_eq!(token.address.to_hex(), "12a2504a78f08930c2d335708fae80696b217d23bd2d473e127d8f5a30e28165de");
+    assert_eq!(token.address.to_base58(), "14zCiH6ybX18HCm3SfLfHSoT48vfzxWUtbNPMt7k61akqDv");
     assert_eq!(&token.roles, &[Role::User, Role::Write]);
 }
 
 #[actix_web::test]
 async fn login_with_disallowed_roles() {
-    let token = "eyJhbGciOiJSaXN0cmV0dG8yNTYiLCJ0eXAiOiJKV1QifQ.eyJhZGRyZXNzIjp7Im5ldHdvcmsiOiJtYWlubmV0IiwicHVibGljX2tleSI6IjEyYTI1MDRhNzhmMDg5MzBjMmQzMzU3MDhmYWU4MDY5NmIyMTdkMjNiZDJkNDczZTEyN2Q4ZjVhMzBlMjgxNjUifSwibm9uY2UiOjE3MTE0NDg2NDksImRlc2lyZWRfcm9sZXMiOlsidXNlciIsIndyaXRlIl19.gm2Z6FxNyMmLT_dcEGu_iH9_wBm029OY_eqw__hZ0yXpa0ccVeBbF1lTfYU5xEhmGtQXtwhOjC8l2SUm9QB8CQ";
+    let token = "eyJhbGciOiJSaXN0cmV0dG8yNTYiLCJ0eXAiOiJKV1QifQ.eyJhZGRyZXNzIjp7IlNpbmdsZSI6eyJuZXR3b3JrIjoibWFpbm5ldCIsImZlYXR1cmVzIjozLCJwdWJsaWNfc3BlbmRfa2V5IjoiYzA4ZjEwOGUzZTQ1ZmZmNjhkYmNmOGJkYTlhMzZjOGUxYTEyMzA5NTlkNzdkNTdiM2RlNmEwYTVmNTE5NjM1NCJ9fSwibm9uY2UiOjE3MjUyOTg1ODUsImRlc2lyZWRfcm9sZXMiOlsidXNlciIsIndyaXRlIiwicmVhZF9hbGwiXX0.CIF4QH5u4Z2MmTPUnorXU1LIl7qgxhZYPzUivmBxrTyu9KUjc3ly8D0csJgKM3xete_c8K_NH9cSSwkWZ-SXAg";
     let (status, body, _) = post_request(token, Err(AuthApiError::RoleNotAllowed(4))).await;
     assert_eq!(status.as_u16(), StatusCode::FORBIDDEN.as_u16());
     assert_eq!(
@@ -73,7 +73,7 @@ async fn login_with_disallowed_roles() {
 
 #[actix_web::test]
 async fn login_with_no_preexisting_user_account() {
-    let token = "eyJhbGciOiJSaXN0cmV0dG8yNTYiLCJ0eXAiOiJKV1QifQ.eyJhZGRyZXNzIjp7Im5ldHdvcmsiOiJtYWlubmV0IiwicHVibGljX2tleSI6IjEyYTI1MDRhNzhmMDg5MzBjMmQzMzU3MDhmYWU4MDY5NmIyMTdkMjNiZDJkNDczZTEyN2Q4ZjVhMzBlMjgxNjUifSwibm9uY2UiOjE3MTE0NDg2NDksImRlc2lyZWRfcm9sZXMiOlsidXNlciIsIndyaXRlIl19.gm2Z6FxNyMmLT_dcEGu_iH9_wBm029OY_eqw__hZ0yXpa0ccVeBbF1lTfYU5xEhmGtQXtwhOjC8l2SUm9QB8CQ";
+    let token = "eyJhbGciOiJSaXN0cmV0dG8yNTYiLCJ0eXAiOiJKV1QifQ.eyJhZGRyZXNzIjp7IlNpbmdsZSI6eyJuZXR3b3JrIjoibWFpbm5ldCIsImZlYXR1cmVzIjozLCJwdWJsaWNfc3BlbmRfa2V5IjoiYzA4ZjEwOGUzZTQ1ZmZmNjhkYmNmOGJkYTlhMzZjOGUxYTEyMzA5NTlkNzdkNTdiM2RlNmEwYTVmNTE5NjM1NCJ9fSwibm9uY2UiOjE3MjUyOTg1ODUsImRlc2lyZWRfcm9sZXMiOlsidXNlciIsIndyaXRlIiwicmVhZF9hbGwiXX0.CIF4QH5u4Z2MmTPUnorXU1LIl7qgxhZYPzUivmBxrTyu9KUjc3ly8D0csJgKM3xete_c8K_NH9cSSwkWZ-SXAg";
     let (status, body, _) = post_request(token, Err(AuthApiError::AddressNotFound)).await;
     assert_eq!(status.as_u16(), StatusCode::FORBIDDEN.as_u16());
     assert_eq!(body, r#"{"error":"Authentication Error. User account not found."}"#);
@@ -81,7 +81,7 @@ async fn login_with_no_preexisting_user_account() {
 
 #[actix_web::test]
 async fn login_with_invalid_nonce() {
-    let token = "eyJhbGciOiJSaXN0cmV0dG8yNTYiLCJ0eXAiOiJKV1QifQ.eyJhZGRyZXNzIjp7Im5ldHdvcmsiOiJtYWlubmV0IiwicHVibGljX2tleSI6IjEyYTI1MDRhNzhmMDg5MzBjMmQzMzU3MDhmYWU4MDY5NmIyMTdkMjNiZDJkNDczZTEyN2Q4ZjVhMzBlMjgxNjUifSwibm9uY2UiOjE3MTE0NDg2NDksImRlc2lyZWRfcm9sZXMiOlsidXNlciIsIndyaXRlIl19.gm2Z6FxNyMmLT_dcEGu_iH9_wBm029OY_eqw__hZ0yXpa0ccVeBbF1lTfYU5xEhmGtQXtwhOjC8l2SUm9QB8CQ";
+    let token = "eyJhbGciOiJSaXN0cmV0dG8yNTYiLCJ0eXAiOiJKV1QifQ.eyJhZGRyZXNzIjp7IlNpbmdsZSI6eyJuZXR3b3JrIjoibWFpbm5ldCIsImZlYXR1cmVzIjozLCJwdWJsaWNfc3BlbmRfa2V5IjoiYzA4ZjEwOGUzZTQ1ZmZmNjhkYmNmOGJkYTlhMzZjOGUxYTEyMzA5NTlkNzdkNTdiM2RlNmEwYTVmNTE5NjM1NCJ9fSwibm9uY2UiOjE3MjUyOTg1ODUsImRlc2lyZWRfcm9sZXMiOlsidXNlciIsIndyaXRlIiwicmVhZF9hbGwiXX0.CIF4QH5u4Z2MmTPUnorXU1LIl7qgxhZYPzUivmBxrTyu9KUjc3ly8D0csJgKM3xete_c8K_NH9cSSwkWZ-SXAg";
     let (status, body, _) = post_request(token, Err(AuthApiError::InvalidNonce)).await;
     assert_eq!(status.as_u16(), StatusCode::UNAUTHORIZED.as_u16());
     assert_eq!(

--- a/tari_payment_server/src/endpoint_tests/orders.rs
+++ b/tari_payment_server/src/endpoint_tests/orders.rs
@@ -49,10 +49,9 @@ async fn fetch_my_orders_invalid_sig() {
 async fn try_fetch_another_users_orders_as_admin() {
     let _ = env_logger::try_init().ok();
     let token = valid_token(vec![Role::ReadAll]);
-    let (status, body) =
-        get_request(&token, "/orders/b4db54f75421a02b0d0056fb7203df23c742b25e41283976bdaa7fe63de1ad234d", configure)
-            .await
-            .expect("Request failed");
+    let (status, body) = get_request(&token, "/orders/14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2", configure)
+        .await
+        .expect("Request failed");
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body, ORDERS_JSON);
 }
@@ -71,8 +70,7 @@ async fn try_fetch_another_users_orders_as_normal_user() {
 fn valid_token(roles: Vec<Role>) -> String {
     issue_token(
         JwtClaims {
-            address: TariAddress::from_hex("b4db54f75421a02b0d0056fb7203df23c742b25e41283976bdaa7fe63de1ad234d")
-                .unwrap(),
+            address: TariAddress::from_base58("14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2").unwrap(),
             roles,
         },
         Utc::now() + Days::new(1),
@@ -121,4 +119,4 @@ fn orders_response() -> Vec<Order> {
     ]
 }
 
-const ORDERS_JSON: &str = r#"{"address":"b4db54f75421a02b0d0056fb7203df23c742b25e41283976bdaa7fe63de1ad234d","total_orders":0,"orders":[{"id":0,"order_id":"0000001","customer_id":"1","memo":null,"total_price":100,"original_price":null,"currency":"XTR","created_at":"2024-02-29T13:30:00Z","updated_at":"2024-02-29T13:30:00Z","status":"Paid"},{"id":1,"order_id":"0000002","customer_id":"1","memo":null,"total_price":150,"original_price":null,"currency":"XTR","created_at":"2024-03-15T18:30:00Z","updated_at":"2024-03-16T11:20:00Z","status":"Cancelled"}]}"#;
+const ORDERS_JSON: &str = r#"{"address":"14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2","total_orders":0,"orders":[{"id":0,"order_id":"0000001","customer_id":"1","memo":null,"total_price":100,"original_price":null,"currency":"XTR","created_at":"2024-02-29T13:30:00Z","updated_at":"2024-02-29T13:30:00Z","status":"Paid"},{"id":1,"order_id":"0000002","customer_id":"1","memo":null,"total_price":150,"original_price":null,"currency":"XTR","created_at":"2024-03-15T18:30:00Z","updated_at":"2024-03-16T11:20:00Z","status":"Cancelled"}]}"#;

--- a/tari_payment_server/src/errors.rs
+++ b/tari_payment_server/src/errors.rs
@@ -122,6 +122,7 @@ impl From<PaymentGatewayError> for ServerError {
             OrderModificationForbidden => ServerError::CannotCompleteRequest(e.to_string()),
             AccountShouldExistForOrder(_) | OrderNotFound(_) => ServerError::NoRecordFound(e.to_string()),
             UnsupportedAction(_) => ServerError::CannotCompleteRequest(e.to_string()),
+            InvalidSignature => ServerError::AuthenticationError(AuthError::ValidationError(e.to_string())),
             _ => ServerError::BackendError(e.to_string()),
         }
     }

--- a/tari_payment_server/src/routes.rs
+++ b/tari_payment_server/src/routes.rs
@@ -939,7 +939,7 @@ pub async fn add_authorized_wallet<W: WalletManagement>(
     body: web::Json<NewWalletInfo>,
 ) -> Result<HttpResponse, ServerError> {
     let wallet = body.into_inner();
-    debug!("💻️ POST authorize_new_wallet {}", wallet.address.as_hex());
+    debug!("💻️ POST authorize_new_wallet {}", wallet.address.as_base58());
     api.register_wallet(wallet).await.map_err(|e| {
         info!("💻️ Could not add wallet. {e}");
         ServerError::BackendError(e.to_string())

--- a/taritools/Cargo.toml
+++ b/taritools/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "taritools"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-shopify_tools = { version = "0.2.1", path = "../shopify_tools" }
-tari_payment_server = { version = "0.2.1", path = "../tari_payment_server"}
-tari_payment_engine = { version = "0.2.1", path = "../tari_payment_engine"}
-tpg_common = { version = "0.2.1", path = "../tpg_common"}
+shopify_tools = { version = "0.3.0", path = "../shopify_tools" }
+tari_payment_server = { version = "0.3.0", path = "../tari_payment_server"}
+tari_payment_engine = { version = "0.3.0", path = "../tari_payment_engine"}
+tpg_common = { version = "0.3.0", path = "../tpg_common"}
 
 anyhow = "1.0.44"
 blake2 = "0.10.6"
@@ -16,26 +16,26 @@ clap = { version = "4.5.3", features = ["derive"] }
 digest = "0.10.7"
 dirs = "5.0.1"
 dotenvy = "0.15.0"
-env_logger = "0.11.3"
 dialoguer = { version = "0.11.0", default-features = false, features = ["completion", "fuzzy-select", "history", "editor"] }
+env_logger = "0.11.3"
+futures = "0.3.30"
 indicatif = "0.17.8"
+log = "0.4.21"
+paste = "1.0.15"
 prettytable-rs = "0.10.0"
+qrcode = "0.14.1"
 rand = "0.8.4"
 reqwest = { version = "0.12.2", features = ["json"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.117"
 sqlx = { version = "0.7.3", features = ["runtime-tokio", "chrono"] }
-tari_crypto = "0.20.0"
-tari_common = "1.0.0-rc.5"
-tari_common_types = "1.0.0-rc.5"
+tari_crypto = "0.20.3"
+tari_common = {version = "1.3.1-pre.1", git = "https://github.com/tari-project/tari.git", package = "tari_common", tag = "v1.3.1-pre.1" }
+tari_common_types = {version = "1.3.1-pre.1", git = "https://github.com/tari-project/tari.git", package = "tari_common_types", tag = "v1.3.1-pre.1" }
+tari_key_manager = { version = "1.3.1-pre.1", git = "https://github.com/tari-project/tari.git", package = "tari_key_manager", tag = "v1.3.1-pre.1" }
 tari-jwt = {  version = "0.1.0", git = "https://github.com/tari-project/tari-jwt.git", branch = "main" }
-tari_key_manager = { version = "1.0.0-rc.8", git = "https://github.com/tari-project/tari.git", package = "tari_key_manager", branch = "nextnet" }
 tokio = "1.37.0"
 toml = "0.8.14"
-log = "0.4.21"
-futures = "0.3.30"
-paste = "1.0.15"
-qrcode = "0.14.1"
 url = { version = "2.5.2", features = ["serde"] }
 urlencoding = "2.1.3"
 zeroize = "1.8.1"

--- a/taritools/src/interactive/formatting.rs
+++ b/taritools/src/interactive/formatting.rs
@@ -57,7 +57,7 @@ pub fn format_addresses(addresses: &[AccountAddress]) -> String {
     table.set_titles(row!["Hex", "Emoji Id", "Created At", "Updated At"]);
     addresses.iter().for_each(|address| {
         let a = address.address.as_address();
-        table.add_row(row![a.to_hex(), a.to_emoji_string(), address.created_at, address.updated_at]);
+        table.add_row(row![a.to_base58(), a.to_emoji_string(), address.created_at, address.updated_at]);
     });
     markdown_style(&mut table);
     table.to_string()
@@ -189,7 +189,7 @@ pub fn format_wallet_list(wallets: &[WalletInfo]) -> String {
 pub fn format_payments_result(payments: PaymentsResult) -> Result<String> {
     let mut f = String::new();
     writeln!(f, "===============================================================================")?;
-    writeln!(f, "Payments for {});", payments.address.as_hex())?;
+    writeln!(f, "Payments for {});", payments.address.as_base58())?;
     writeln!(
         f,
         "{count:<4} payments.                                          Total value: {value}",
@@ -216,7 +216,7 @@ pub fn payment_to_row(payment: &Payment) -> Row {
         Cell::new(&payment.txid),
         Cell::new(&payment.amount.to_string()),
         Cell::new(&payment.status.to_string()),
-        Cell::new(&payment.sender.as_hex()),
+        Cell::new(&payment.sender.as_base58()),
         Cell::new(&payment.order_id.clone().map(|id| id.to_string()).unwrap_or_default()),
         Cell::new(&payment.memo.clone().unwrap_or_default()),
         Cell::new(&payment.created_at.to_string()),
@@ -247,7 +247,7 @@ pub fn format_addresses_with_qr_code(addresses: &[TariAddress]) -> String {
 }
 
 pub fn format_address_with_qr_code(address: &TariAddress) -> (String, String, String) {
-    let qr_link = format!("tari://{}/transactions/send?tariAddress={}", address.network(), address.to_hex());
+    let qr_link = format!("tari://{}/transactions/send?tariAddress={}", address.network(), address.to_base58());
     let code = QrCode::new(qr_link)
         .map(|code| {
             code.render::<unicode::Dense1x2>()
@@ -257,7 +257,7 @@ pub fn format_address_with_qr_code(address: &TariAddress) -> (String, String, St
                 .build()
         })
         .unwrap_or_default();
-    (address.to_hex(), address.to_emoji_string(), code)
+    (address.to_base58(), address.to_emoji_string(), code)
 }
 
 pub fn format_claimed_order(order: &ClaimedOrder) -> Result<String> {

--- a/taritools/src/jwt_token.rs
+++ b/taritools/src/jwt_token.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use serde::Serialize;
 use tari_common::configuration::Network;
-use tari_common_types::tari_address::TariAddress;
+use tari_common_types::tari_address::{TariAddress, TariAddressFeatures};
 use tari_crypto::{
     keys::PublicKey,
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -19,7 +19,7 @@ pub fn print_jwt_token(sk: String, network: Network, roles: Vec<String>) {
         return;
     };
     let pubkey = RistrettoPublicKey::from_secret_key(&sk);
-    let address = TariAddress::new(pubkey.clone(), network);
+    let address = TariAddress::new_single_address(pubkey.clone(), network, TariAddressFeatures::default());
     let nonce = Utc::now().timestamp() as u64;
     let claims = LoginToken { address, nonce, desired_roles: roles };
     let claims = Claims::new(claims);
@@ -27,7 +27,7 @@ pub fn print_jwt_token(sk: String, network: Network, roles: Vec<String>) {
     let msg = Ristretto256.token(&header, &claims, &Ristretto256SigningKey(sk)).unwrap_or_else(|e| e.to_string());
     println!("----------------------------- Access Token -----------------------------");
     println!("address: {}", claims.custom.address);
-    println!("address: {}", claims.custom.address.to_hex());
+    println!("address: {}", claims.custom.address.to_base58());
     println!("network: {}", claims.custom.address.network());
     println!("nonce: {}", claims.custom.nonce);
     println!("roles: {:}", claims.custom.desired_roles.into_iter().collect::<Vec<String>>().join(","));

--- a/taritools/src/keys.rs
+++ b/taritools/src/keys.rs
@@ -1,6 +1,6 @@
 use rand::thread_rng;
 use tari_common::configuration::Network;
-use tari_common_types::tari_address::TariAddress;
+use tari_common_types::tari_address::{TariAddress, TariAddressFeatures};
 use tari_crypto::{
     keys::PublicKey,
     ristretto::{RistrettoPublicKey, RistrettoSecretKey},
@@ -24,11 +24,16 @@ impl KeyInfo {
     }
 
     pub fn address(&self) -> TariAddress {
-        TariAddress::new(self.pk.clone(), self.network)
+        TariAddress::new_single_address(self.pk.clone(), self.network, TariAddressFeatures::default())
     }
 
+    #[deprecated(since = "0.3.0", note = "Use as_base58 instead")]
     pub fn address_as_hex(&self) -> String {
         self.address().to_hex()
+    }
+
+    pub fn address_as_base58(&self) -> String {
+        self.address().to_base58()
     }
 
     pub fn address_as_emoji_string(&self) -> String {

--- a/taritools/src/main.rs
+++ b/taritools/src/main.rs
@@ -207,7 +207,8 @@ fn print_new_address(network: Network) {
     println!("Network: {}", info.network);
     println!("Secret key: {}", info.sk.reveal());
     println!("Public key: {:x}", info.pk);
-    println!("Address: {}", info.address_as_hex());
+    println!("Address (hex): {}", info.address_as_hex());
+    println!("Address      : {}", info.address_as_base58());
     println!("Emoji ID: {}", info.address_as_emoji_string());
     println!("------------------------------------------------------------------------");
 }

--- a/taritools/src/memo.rs
+++ b/taritools/src/memo.rs
@@ -15,7 +15,7 @@ pub fn print_memo_signature(params: MemoSignatureParams) {
     match MemoSignature::create(key_info.address(), params.order_id, &key_info.sk) {
         Ok(signature) => {
             println!("----------------------------- Memo Signature -----------------------------");
-            println!("Wallet address: {}", key_info.address_as_hex());
+            println!("Wallet address: {}", key_info.address_as_base58());
             println!("Public key    : {:x}", &key_info.pk);
             println!("emoji id      : {}", key_info.address_as_emoji_string());
             println!("Secret        : {}", &key_info.sk.reveal().to_string());

--- a/taritools/src/payments.rs
+++ b/taritools/src/payments.rs
@@ -87,7 +87,7 @@ pub fn print_payment_auth(params: PaymentAuthParams) {
     match build_auth(&params.secret, params.network, params.nonce, &payment) {
         Ok((wallet_signature, key_info)) => {
             println!("----------------------------- Wallet Auth -----------------------------");
-            println!("Wallet address: {}", key_info.address_as_hex());
+            println!("Wallet address: {}", key_info.address_as_base58());
             println!("Public key    : {:x}", &key_info.pk);
             println!("emoji id      : {}", key_info.address_as_emoji_string());
             println!("Secret        : {}", &key_info.sk.reveal().to_string());
@@ -138,7 +138,7 @@ pub fn print_tx_confirm(params: TxConfirmParams) {
     match build_auth(&params.secret, params.network, params.nonce, &confirmation) {
         Ok((wallet_signature, key_info)) => {
             println!("----------------------------- Wallet Auth -----------------------------");
-            println!("Wallet address: {}", key_info.address_as_hex());
+            println!("Wallet address: {}", key_info.address_as_base58());
             println!("Public key    : {:x}", &key_info.pk);
             println!("emoji id      : {}", key_info.address_as_emoji_string());
             println!("Secret        : {}", &key_info.sk.reveal().to_string());

--- a/taritools/src/tari_payment_server/client.rs
+++ b/taritools/src/tari_payment_server/client.rs
@@ -121,7 +121,7 @@ impl PaymentServerClient {
     }
 
     pub async fn remove_authorized_wallet(&self, address: &TariAddress) -> Result<()> {
-        let url = self.url(&format!("/api/wallets/{}", address.to_hex()))?;
+        let url = self.url(&format!("/api/wallets/{}", address.to_base58()))?;
         let res = self.client.delete(url).header("tpg_access_token", self.access_token.clone()).send().await?;
         if !res.status().is_success() {
             let msg = res.text().await?;
@@ -215,7 +215,7 @@ impl PaymentServerClient {
     }
 
     pub async fn history_for_address(&self, address: &TariAddress) -> Result<FullAccount> {
-        self.auth_get_request(&format!("/api/history/address/{}", address.to_hex())).await
+        self.auth_get_request(&format!("/api/history/address/{}", address.to_base58())).await
     }
 
     pub async fn history_for_id(&self, account_id: i64) -> Result<FullAccount> {
@@ -248,7 +248,7 @@ impl PaymentServerClient {
     }
 
     pub async fn orders_for_address(&self, address: TariAddress) -> Result<OrderResult> {
-        self.auth_get_request(&format!("/api/orders/{}", address.to_hex())).await
+        self.auth_get_request(&format!("/api/orders/{}", address.to_base58())).await
     }
 
     pub async fn order_by_id(&self, order_id: &OrderId) -> Result<Option<Order>> {
@@ -293,7 +293,7 @@ impl PaymentServerClient {
     }
 
     pub async fn payments_for_address(&self, address: TariAddress) -> Result<PaymentsResult> {
-        self.auth_get_request(&format!("/api/payments/{}", address.to_hex())).await
+        self.auth_get_request(&format!("/api/payments/{}", address.to_base58())).await
     }
 
     pub async fn issue_credit(&self, customer_id: &str, amount: MicroTari, reason: String) -> Result<Vec<Order>> {

--- a/tpg_common/Cargo.toml
+++ b/tpg_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tpg_common"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Support the new Tari address format as described in [this unmerged RFC](https://github.com/tari-project/rfcs/pull/146/files?short_path=a7df527#diff-a7df527e6c8e2063c358a989234ee92d0225f85c1157f6677e3e82907c7528bb).

Key steps:
* Upgrades tari dependencies, in particular, `tari_common_types`, which contains code implementing the new Tari address format implementation.
* Use "Single"-address form (where view key and spend key are the same).
* Public key is represented by the `comms_public_key`. This API call is chosen because the essential use case of the payment server is for wallets to identify themselves using their comms key.
* We assume default address features in all cases.

Changes made to get tests passing
---------------------------------

* Change cucumber user seed to use new Base58 address format.
* Update all instances of address formats in tests with new format.
* Change all ocurrances of `to_hex()` to `to_base58()`
* Replaced `as_hex()` with `as_base58()` for addess serialization.
* Updated tari_payment_engine tests to expect base58 addresses.
* Updated tokens in tests to match new address format.
* Update DONATION_WALLET_ADDRESS to use new address format. Also updates address in .env.sample
* Update payment authorisation signatures in tests for new address
* Replace instances of `TariAddress::from_hex()` to `TariAddress::from_base58()` when converting from database rows.
* Update all signatures for payments, confirmations and claims in order fulfillment tests