### PR TITLE
tests: test order - claim - pay permutations

### DIFF
--- a/e2e/tests/cucumber/steps.rs
+++ b/e2e/tests/cucumber/steps.rs
@@ -292,6 +292,19 @@ async fn check_order_state(world: &mut TPGWorld, order_id: String, state: String
     assert_eq!(order.status, status);
 }
 
+#[then(regex = r#"^Account (\d+) has a (current|pending) balance of (\d+) Tari$"#)]
+async fn check_account_balance(world: &mut TPGWorld, acc_id: i64, bal_type: String, balance: i64) {
+    let db = world.db.as_ref().expect("No database connection");
+    let account = db.fetch_user_account(acc_id).await.expect("Failed to fetch account").expect("No account found");
+    let expected_balance = MicroTari::from_tari(balance);
+    let actual_balance = match bal_type.as_str() {
+        "current" => account.current_balance,
+        "pending" => account.current_pending,
+        _ => panic!("Invalid balance type: {bal_type}"),
+    };
+    assert_eq!(actual_balance, expected_balance);
+}
+
 #[then(regex = r#"^(\w+) has a (current|pending) balance of (\d+) Tari$"#)]
 async fn check_balance(world: &mut TPGWorld, user: String, bal_type: String, balance: i64) {
     let db = world.db.as_ref().expect("No database connection");

--- a/e2e/tests/features/claim_order.feature
+++ b/e2e/tests/features/claim_order.feature
@@ -101,3 +101,14 @@ Feature: Order claiming
       "claimant": "14NPqUxFyJwbZ6wJ8hpuTuX5oWbQt7XeMJWXMZdMSiA19Fj"
     }
     """
+
+  Scenario: Claiming an order before making the order fails
+    When User POSTs to "/order/claim" with body
+    """
+    {
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+      "order_id":"does-not-exist",
+      "signature":"1e06e8f1de61644ba380c8d82a124e0b288b86501b6283e93bc8094ddd6d980765c4edc2b73dca69847cb9f15e3685f67ed4431ee527e9ef63ae176d0c5f2a09"
+    }
+    """
+    Then I receive a 404 NotFound response with the message 'The requested order does-not-exist does not exist'

--- a/tari_payment_engine/src/tpe_api/order_flow_api.rs
+++ b/tari_payment_engine/src/tpe_api/order_flow_api.rs
@@ -203,7 +203,7 @@ where B: PaymentGatewayDatabase
     pub async fn confirm_payment(&self, txid: String) -> Result<Payment, PaymentGatewayError> {
         trace!("🔄️✅️ Payment {txid} is being marked as confirmed");
         let (account_id, payment) = self.db.update_payment_status(&txid, TransferStatus::Confirmed).await?;
-        let payable = self.db.fetch_payable_orders(account_id).await?;
+        let payable = self.db.fetch_payable_orders_for_address(payment.sender.as_address()).await?;
         trace!("🔄️✅️ {} fulfillable orders fetched for account #{account_id}", payable.len());
         let paid_orders = self.db.try_pay_orders(account_id, &payable).await?;
         debug!("🔄️✅️ [{txid}] confirmed. {} orders are paid for account #{account_id}", paid_orders.len());


### PR DESCRIPTION
Adds tests that catch a bug where some db transactions were not being committed.

fix: check all accounts on confirmation

When a payment is confirmed, we check all accounts associated with the sender address to see if there are any orders that can be paid.

This required adding another API call,
`fetch_payable_oders_for_address`, which retrieves this list of orders.

Updated the definition of payable to "New" orders only. The tests showed up an issue where "Unclaimed" orders would be paid erroneously under certain conditions.

This change also uncovered a bug in the tests (a test was passing when it shouldn't have because the claim signature was wrong. The test correctly failed after this fix, and passed again wonce the signature was updated to the new address format).

Added `fetch_payment_by_txid` method to the API. This is a fairly fundamental call that was missing until now.