### PR TITLE
fix: millisecond nonce values

### DIFF
--- a/taritools/scripts/tps_notify.sh
+++ b/taritools/scripts/tps_notify.sh
@@ -15,12 +15,25 @@ register_received_payment() {
 }
 
 register_confirmation() {
+  echo "Signalling payment (possibly again)"
+  ${BIN} wallet received --profile "$PROFILE" --amount "$2" --txid $3 --memo "$4" --sender $5 &>>$LOGFILE
+  sleep 2
   ${BIN} wallet confirmed --profile "$PROFILE" --txid $3 &>>$LOGFILE
   echo "Registering confirmation received is complete" >> $LOGFILE
 }
 
 # Log the event
-echo "$@" >> $LOGFILE
+escaped_args=""
+
+for arg in "$@"; do
+  # Surround the argument with single quotes and append to the variable
+  escaped_args+="'$arg' "
+done
+
+# Trim the trailing space
+escaped_args=$(echo "$escaped_args" | sed 's/ *$//')
+echo $escaped_args >> $LOGFILE
+
 if [ -n "${12}" ]; then
   if [ "$1" == "received" ]; then
     echo "Registering payment received" >> $LOGFILE

--- a/taritools/src/wallet.rs
+++ b/taritools/src/wallet.rs
@@ -37,7 +37,7 @@ fn load_profile(name: &str) -> Result<Profile> {
 }
 
 fn new_nonce() -> i64 {
-    Utc::now().timestamp()
+    Utc::now().timestamp_millis()
 }
 
 async fn notify_server_about_payment(params: ReceivedPaymentParams) -> Result<()> {


### PR DESCRIPTION
Wallet payment authorisations can come more than 1x per second, meaning some notifications get rejected as a result of resuing a nonce.

Taritools wallet commands will use millisecond epochs to improve this resolution.

Also log the notification parameters with quotes to allow for easier replay of notifications.