### PR TITLE
fix: release tag script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "e2e"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3676,7 +3676,7 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shopify_tools"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 dependencies = [
  "chrono",
  "graphql-parser",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "tari_payment_engine"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 dependencies = [
  "blake2",
  "chrono",
@@ -4374,7 +4374,7 @@ dependencies = [
 
 [[package]]
 name = "tari_payment_server"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 dependencies = [
  "actix-http",
  "actix-jwt-auth-middleware",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "taritools"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4798,7 +4798,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tpg_common"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 dependencies = [
  "serde",
  "sqlx",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "e2e"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-shopify_tools = { version = "1.1.0-beta", path = "../shopify_tools" }
-tari_payment_engine = { version = "1.1.0-beta", path = "../tari_payment_engine", features = ["test_utils"] }
-tari_payment_server = { version = "1.1.0-beta", path = "../tari_payment_server" }
-tpg_common = { version = "1.1.0-beta", path = "../tpg_common" }
+shopify_tools = { version = "1.2.0-beta", path = "../shopify_tools" }
+tari_payment_engine = { version = "1.2.0-beta", path = "../tari_payment_engine", features = ["test_utils"] }
+tari_payment_server = { version = "1.2.0-beta", path = "../tari_payment_server" }
+tpg_common = { version = "1.2.0-beta", path = "../tpg_common" }
 
 log = "0.4.21"
 tari_common_types = {version = "1.3.1-pre.1", git = "https://github.com/tari-project/tari.git", package = "tari_common_types", tag = "v1.3.1-pre.1" }

--- a/scripts/release_tag.sh
+++ b/scripts/release_tag.sh
@@ -17,16 +17,19 @@ for f in ${CARGO_FILES[@]}; do
         if [ "$f" == "$f2" ]; then
             continue
         fi
+        echo "Updating dependencies in $f2"
         # Extract the package name from the file path
         PACKAGE=$(basename "$(dirname "$f2")")
         # if package is the current directory (.), skip
         if [ "$PACKAGE" == "." ]; then
             continue
         fi
+        echo "    Updating ${PACKAGE} to $NEW_VER"
+
 
         #echo "Setting ${PACKAGE} in $f to $NEW_VER.."
         # Use sed to update the version number for the specific package
-        sed -i "s/${PACKAGE}\s*=\s*{\s*version\s*=\s*\"[0-9\.]*\"/${PACKAGE} = { version = \"$NEW_VER\"/" "$f"
+        sed -i "s/${PACKAGE}\s*=\s*{\s*version\s*=\s*\"[^\"]*\"/${PACKAGE} = { version = \"$NEW_VER\"/" "$f"
     done
     echo "Updated $f"
 done

--- a/shopify_tools/Cargo.toml
+++ b/shopify_tools/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "shopify_tools"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 edition = "2021"
 
 [dependencies]
-tpg_common = { version = "1.1.0-beta", path = "../tpg_common" }
+tpg_common = { version = "1.2.0-beta", path = "../tpg_common" }
 chrono = { version = "0.4.31", features = ["serde"] }
 graphql-parser = "0.4.0"
 log = "0.4.21"

--- a/tari_payment_engine/Cargo.toml
+++ b/tari_payment_engine/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tari_payment_engine"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 edition = "2021"
 description = "Database backend for Tari payment gateway"
 
 [dependencies]
-tpg_common = { version = "1.1.0-beta", path = "../tpg_common" }
+tpg_common = { version = "1.2.0-beta", path = "../tpg_common" }
 
 blake2 = "0.10.6"
 chrono = { version = "0.4.31", features = ["serde"] }

--- a/tari_payment_server/Cargo.toml
+++ b/tari_payment_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_payment_server"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,9 +12,9 @@ shopify = ["shopify_tools"]
 
 
 [dependencies]
-shopify_tools = { version = "1.1.0-beta", path = "../shopify_tools", optional = true }
-tpg_common = { version = "1.1.0-beta", path = "../tpg_common" }
-tari_payment_engine = { version = "1.1.0-beta", path = "../tari_payment_engine" }
+shopify_tools = { version = "1.2.0-beta", path = "../shopify_tools", optional = true }
+tpg_common = { version = "1.2.0-beta", path = "../tpg_common" }
+tari_payment_engine = { version = "1.2.0-beta", path = "../tari_payment_engine" }
 
 actix-jwt-auth-middleware = { version = "0.5.0", git = "https://github.com/cjs77/actix-jwt-auth-middleware.git", branch = "master" }
 actix-http = "3.8.0"

--- a/taritools/Cargo.toml
+++ b/taritools/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "taritools"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 edition = "2021"
 
 [dependencies]
-shopify_tools = { version = "1.1.0-beta", path = "../shopify_tools" }
-tari_payment_server = { version = "1.1.0-beta", path = "../tari_payment_server"}
-tari_payment_engine = { version = "1.1.0-beta", path = "../tari_payment_engine"}
-tpg_common = { version = "1.1.0-beta", path = "../tpg_common"}
+shopify_tools = { version = "1.2.0-beta", path = "../shopify_tools" }
+tari_payment_server = { version = "1.2.0-beta", path = "../tari_payment_server"}
+tari_payment_engine = { version = "1.2.0-beta", path = "../tari_payment_engine"}
+tpg_common = { version = "1.2.0-beta", path = "../tpg_common"}
 
 anyhow = "1.0.44"
 blake2 = "0.10.6"

--- a/tpg_common/Cargo.toml
+++ b/tpg_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tpg_common"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
fix: release tag script

Version were assumed to be only digits and points. This is fixed now.