### PR TITLE
fix: display correct version in taritools

### DIFF
--- a/taritools/Cargo.toml
+++ b/taritools/Cargo.toml
@@ -2,6 +2,7 @@
 name = "taritools"
 version = "1.2.0-beta"
 edition = "2021"
+authors = ["CjS <https://y.at/👁️👃👁️>"]
 
 [dependencies]
 shopify_tools = { version = "1.2.0-beta", path = "../shopify_tools" }

--- a/taritools/src/main.rs
+++ b/taritools/src/main.rs
@@ -30,7 +30,7 @@ use crate::{
 
 pub const APP_NAME: &str = env!("CARGO_PKG_NAME");
 #[derive(Parser, Debug)]
-#[command(version = "1.0.0", author = "CjS77")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 pub struct Arguments {
     /// The network to use (nextnet, stagenet, mainnet). Default is mainnet.
     #[arg(short, long, default_value = "mainnet")]


### PR DESCRIPTION
`taritools --version` now displays the version as pulled from the Cargo.toml manifest.