### PR TITLE
fix: my open orders

### DIFF
--- a/tari_payment_engine/src/traits/account_management.rs
+++ b/tari_payment_engine/src/traits/account_management.rs
@@ -67,7 +67,7 @@ impl From<sqlx::Error> for AccountApiError {
 /// merchant accounts and orders. `AccountManagement` provides methods for querying information about these accounts.
 #[allow(async_fn_in_trait)]
 pub trait AccountManagement {
-    async fn fetch_orders_for_address(&self, acaddress: &TariAddress) -> Result<Vec<Order>, AccountApiError>;
+    async fn fetch_orders_for_address(&self, address: &TariAddress) -> Result<Vec<Order>, AccountApiError>;
 
     async fn fetch_order_by_order_id(&self, order_id: &OrderId) -> Result<Option<Order>, AccountApiError>;
 

--- a/taritools/src/interactive/mod.rs
+++ b/taritools/src/interactive/mod.rs
@@ -266,7 +266,7 @@ impl InteractiveApp {
                 .expect("User is logged in. Client should not be None")
                 .my_unfulfilled_orders()
                 .await
-                .map(|o| format_orders(&o));
+                .and_then(format_order_result);
         }
         handle_response(res)
     }

--- a/taritools/src/tari_payment_server/client.rs
+++ b/taritools/src/tari_payment_server/client.rs
@@ -199,7 +199,7 @@ impl PaymentServerClient {
         self.auth_get_request("/api/orders").await
     }
 
-    pub async fn my_unfulfilled_orders(&self) -> Result<Vec<Order>> {
+    pub async fn my_unfulfilled_orders(&self) -> Result<OrderResult> {
         self.auth_get_request("/api/unfulfilled_orders").await
     }
 


### PR DESCRIPTION
The return type for unfulfilled orders is now `OrderResult`, so this updates the interactive taritools command to expect that instead of `Vec<Order>`.