### PR TITLE
feat: account settlements

### DIFF
--- a/e2e/tests/features/settle_accounts.feature
+++ b/e2e/tests/features/settle_accounts.feature
@@ -1,0 +1,124 @@
+@settle
+Feature: Settle accounts
+  Background:
+    Given a database with some accounts
+
+  Scenario: Unuathenticated user cannot access the `settle_address` endpoint
+      When User POSTs to "/api/settle/address/14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt" with body
+      Then I receive a 401 Unauthenticated response with the message 'An error occurred, no cookie containing a jwt was found in the request.'
+
+  Scenario: Unuathenticated user cannot access the `settle_customer` endpoint
+    When User POSTs to "/api/settle/customer/alice" with body
+    Then I receive a 401 Unauthenticated response with the message 'An error occurred, no cookie containing a jwt was found in the request.'
+
+  Scenario: Standard user can settle their own address
+    Given some role assignments
+    # Does not cause order matching
+    When a direct payment of 65 XTR is placed in Alice's account
+    Then order "3" is in state New
+    When Alice authenticates with nonce = 1 and roles = "user"
+    When Alice POSTs to "/api/settle" with body
+    Then I receive a 200 Ok response
+    And I receive a partial JSON response:
+    """
+    {
+      "orders_paid":[
+        {"order_id":"3","customer_id":"alice","total_price":65000000,"status":"Paid"}
+      ],
+      "settlements":[
+        {"id":1,"order_id":"3","payment_address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt","settlement_type":"single","amount":65000000}
+      ]
+    }
+    """
+    And the OrderPaid trigger fires with
+    """
+    {
+      "order": {
+        "order_id": "3",
+        "customer_id": "alice",
+        "total_price": 65000000,
+        "currency": "XTR",
+        "status": "Paid"
+      }
+    }
+    """
+    And order "3" is in state Paid
+
+
+  Scenario: Standard user cannot settle someone else's address
+    Given some role assignments
+    When Alice authenticates with nonce = 1 and roles = "user"
+    When Alice POSTs to "/api/settle/address/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+  Scenario: Standard user cannot settle customer id
+    Given some role assignments
+    When Alice authenticates with nonce = 1 and roles = "user"
+    When Alice POSTs to "/api/settle/customer/bob" with body
+    Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
+
+  Scenario: Admin user can settle someone else's address
+    Given some role assignments
+    When Admin authenticates with nonce = 1 and roles = "write"
+    When a direct payment of 65 XTR is placed in Alice's account
+    # Because the direct deposit does not trigger matching, the order is still unpaid...
+    Then order "3" is in state New
+    When Admin POSTs to "/api/settle/address/14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt" with body
+    Then I receive a 200 Ok response
+    And I receive a partial JSON response:
+    """
+    {
+      "orders_paid":[
+        {"order_id":"3","customer_id":"alice","total_price":65000000,"status":"Paid"}
+      ],
+      "settlements":[
+        {"id":1,"order_id":"3","payment_address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt","settlement_type":"single","amount":65000000}
+      ]
+    }
+    """
+    And the OrderPaid trigger fires with
+    """
+    {
+      "order": {
+        "order_id": "3",
+        "customer_id": "alice",
+        "total_price": 65000000,
+        "currency": "XTR",
+        "status": "Paid"
+      }
+    }
+    """
+    And order "3" is in state Paid
+
+  Scenario: Admin user can settle someone else's customer id
+    Given some role assignments
+    When Admin authenticates with nonce = 1 and roles = "write"
+    When a direct payment of 65 XTR is placed in Alice's account
+    # Because the direct deposit does not trigger matching, the order is still unpaid...
+    Then order "3" is in state New
+    When Admin POSTs to "/api/settle/customer/alice" with body
+    Then I receive a 200 Ok response
+    And I receive a partial JSON response:
+    """
+    {
+      "orders_paid":[
+        {"order_id":"3","customer_id":"alice","total_price":65000000,"status":"Paid"}
+      ],
+      "settlements":[
+        {"id":1,"order_id":"3","payment_address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt","settlement_type":"single","amount":65000000}
+      ]
+    }
+    """
+    And the OrderPaid trigger fires with
+    """
+    {
+      "order": {
+        "order_id": "3",
+        "customer_id": "alice",
+        "total_price": 65000000,
+        "currency": "XTR",
+        "status": "Paid"
+      }
+    }
+    """
+    And order "3" is in state Paid

--- a/tari_payment_engine/src/sqlite/db/accounts.rs
+++ b/tari_payment_engine/src/sqlite/db/accounts.rs
@@ -183,6 +183,18 @@ pub(crate) async fn addresses(
     Ok(addresses)
 }
 
+pub(crate) async fn customer_ids_for_address(
+    address: &TariAddress,
+    conn: &mut SqliteConnection,
+) -> Result<Vec<String>, AccountApiError> {
+    let rows = sqlx::query("SELECT customer_id FROM address_customer_id_link WHERE address = $1")
+        .bind(address.to_base58())
+        .fetch_all(conn)
+        .await?;
+    let customer_ids = rows.into_iter().map(|r| r.get("customer_id")).collect::<Vec<String>>();
+    Ok(customer_ids)
+}
+
 async fn with_pagination(
     q: &str,
     pagination: &Pagination,

--- a/tari_payment_engine/src/sqlite/sqlite_impl.rs
+++ b/tari_payment_engine/src/sqlite/sqlite_impl.rs
@@ -572,6 +572,12 @@ impl AccountManagement for SqliteDatabase {
         let balances = accounts::customer_order_balance(customer_id, &mut conn).await?;
         Ok(balances)
     }
+
+    async fn fetch_customer_ids_for_address(&self, address: &TariAddress) -> Result<Vec<String>, AccountApiError> {
+        let mut conn = self.pool.acquire().await?;
+        let ids = accounts::customer_ids_for_address(address, &mut conn).await?;
+        Ok(ids)
+    }
 }
 
 impl AuthManagement for SqliteDatabase {

--- a/tari_payment_engine/src/traits/account_management.rs
+++ b/tari_payment_engine/src/traits/account_management.rs
@@ -105,4 +105,7 @@ pub trait AccountManagement {
     ///
     /// This includes the total paid prders, current orders, and expired and cancelled orders.
     async fn fetch_customer_order_balance(&self, customer_id: &str) -> Result<CustomerOrderBalance, AccountApiError>;
+
+    /// Fetches all customer ids associated with the given address
+    async fn fetch_customer_ids_for_address(&self, address: &TariAddress) -> Result<Vec<String>, AccountApiError>;
 }

--- a/tari_payment_engine/src/traits/data_objects.rs
+++ b/tari_payment_engine/src/traits/data_objects.rs
@@ -81,7 +81,7 @@ impl MultiAccountPayment {
         self.settlements.iter().map(|s| s.amount).sum()
     }
 
-    /// Merge the payments into a single payment, using the first payment's address as the representative address.
+    /// Merge the payments into a single payment.
     /// You can retrieve the other addresses from the `settlements` field.
     pub fn merge<I: IntoIterator<Item = MultiAccountPayment>>(payments: I) -> Option<Self> {
         let mut iter = payments.into_iter();

--- a/tari_payment_server/src/endpoint_tests/mocks.rs
+++ b/tari_payment_server/src/endpoint_tests/mocks.rs
@@ -22,6 +22,7 @@ mock! {
         async fn fetch_customer_balance(&self, customer_id: &str) -> Result<CustomerBalance, AccountApiError>;
         async fn history_for_customer(&self, customer_id: &str) -> Result<CustomerHistory, AccountApiError>;
         async fn fetch_customer_order_balance(&self, customer_id: &str) -> Result<CustomerOrderBalance, AccountApiError>;
+        async fn fetch_customer_ids_for_address(&self, address: &TariAddress) -> Result<Vec<String>, AccountApiError>;
     }
 }
 

--- a/tari_payment_server/src/routes.rs
+++ b/tari_payment_server/src/routes.rs
@@ -526,6 +526,48 @@ pub async fn addresses<B: AccountManagement>(
     Ok(HttpResponse::Ok().json(addresses))
 }
 
+route!(settle_address => Post "/settle/address/{address}" impl PaymentGatewayDatabase where requires [Role::Write]);
+pub async fn settle_address<B: PaymentGatewayDatabase>(
+    path: web::Path<SerializedTariAddress>,
+    api: web::Data<OrderFlowApi<B>>,
+) -> Result<HttpResponse, ServerError> {
+    let address = path.into_inner().to_address();
+    debug!("💻️ GET settle_address for {address}");
+    let result = api.settle_orders_for_address(&address).await.map_err(|e| {
+        debug!("💻️ Could not settle address. {e}");
+        e
+    })?;
+    Ok(HttpResponse::Ok().json(result))
+}
+
+route!(settle_customer => Post "/settle/customer/{customer_id}" impl PaymentGatewayDatabase where requires [Role::Write]);
+pub async fn settle_customer<B: PaymentGatewayDatabase>(
+    path: web::Path<String>,
+    api: web::Data<OrderFlowApi<B>>,
+) -> Result<HttpResponse, ServerError> {
+    let customer_id = path.into_inner();
+    debug!("💻️ GET settle_customer for {customer_id}");
+    let result = api.settle_orders_for_customer_id(&customer_id).await.map_err(|e| {
+        debug!("💻️ Could not settle customer. {e}");
+        e
+    })?;
+    Ok(HttpResponse::Ok().json(result))
+}
+
+route!(settle_my_account => Post "/settle" impl PaymentGatewayDatabase);
+pub async fn settle_my_account<B: PaymentGatewayDatabase>(
+    claims: JwtClaims,
+    api: web::Data<OrderFlowApi<B>>,
+) -> Result<HttpResponse, ServerError> {
+    let address = claims.address;
+    debug!("💻️ GET settle_address for {address}");
+    let result = api.settle_orders_for_address(&address).await.map_err(|e| {
+        debug!("💻️ Could not settle address. {e}");
+        e
+    })?;
+    Ok(HttpResponse::Ok().json(result))
+}
+
 //----------------------------------------------   Payments  ----------------------------------------------------
 
 route!(my_payments => Get "/payments" impl AccountManagement);

--- a/tari_payment_server/src/server.rs
+++ b/tari_payment_server/src/server.rs
@@ -61,6 +61,9 @@ use crate::{
         ReassignOrderRoute,
         RemoveAuthorizedWalletRoute,
         ResetOrderRoute,
+        SettleAddressRoute,
+        SettleCustomerRoute,
+        SettleMyAccountRoute,
         TxConfirmationNotificationRoute,
         UnfulfilledOrdersRoute,
         UpdateOrderMemoRoute,
@@ -173,6 +176,9 @@ pub fn create_server_instance(
             .service(GetAuthorizedWalletsRoute::<SqliteDatabase>::new())
             .service(RemoveAuthorizedWalletRoute::<SqliteDatabase>::new())
             .service(AddAuthorizedWalletRoute::<SqliteDatabase>::new())
+            .service(SettleAddressRoute::<SqliteDatabase>::new())
+            .service(SettleCustomerRoute::<SqliteDatabase>::new())
+            .service(SettleMyAccountRoute::<SqliteDatabase>::new())
             .service(CheckTokenRoute::new());
         let use_x_forwarded_for = config.use_x_forwarded_for;
         let use_forwarded = config.use_forwarded;

--- a/taritools/src/interactive/mod.rs
+++ b/taritools/src/interactive/mod.rs
@@ -305,7 +305,7 @@ impl InteractiveApp {
         self.customer_ids.update(client).await?;
         let idx = FuzzySelect::new().with_prompt("Select customer ID").items(self.customer_ids.items()).interact()?;
         let cust_id = &self.customer_ids.items()[idx];
-        let history = client.history_for_id(&cust_id).await?;
+        let history = client.history_for_id(cust_id).await?;
         format_customer_history(&history)
     }
 


### PR DESCRIPTION
There may be edge cases where the order matching algorithms miss a payment/order match. In this instance, we need a method to manually retrigger the matching process.

The `settle` endpoints provide this feature.

Note that users can request a self-trigger for their connected wallets, but we only allow admins to trigger settlements for general customer ids and addresses to prevent a DoS vector.