### PR TITLE
chore: rename account endpoint to balance

### DIFF
--- a/e2e/tests/features/accounts.feature
+++ b/e2e/tests/features/accounts.feature
@@ -1,16 +1,16 @@
-@accounts
+@balances
 Feature: Accounts endpoint
   Background:
     Given a database with some accounts
 
-  Scenario: Unauthenticated user cannot access the `account` endpoint
-    When User GETs to "/api/account" with body
+  Scenario: Unauthenticated user cannot access the `balance` endpoint
+    When User GETs to "/api/balance" with body
     Then I receive a 401 Unauthenticated response with the message 'An error occurred, no cookie containing a jwt was found in the request.'
 
-  Scenario: Standard user can access their own account
+  Scenario: Standard user can access their own balance
     Given some role assignments
     When Alice authenticates with nonce = 1 and roles = "user"
-    When Alice GETs to "/api/account" with body
+    When Alice GETs to "/api/balance" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
@@ -21,17 +21,17 @@ Feature: Accounts endpoint
     }
     """
 
-  Scenario: Standard user cannot access another user's account
+  Scenario: Standard user cannot access another user's balance
     Given some role assignments
     When Alice authenticates with nonce = 1 and roles = "user"
     When Bob authenticates with nonce = 1 and roles = "user"
-    When Alice GETs to "/api/account/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
+    When Alice GETs to "/api/balance/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 403 Forbidden response with the message 'Insufficient permissions.'
 
-  Scenario: User with ReadAll role can access another account
+  Scenario: User with ReadAll role can access another balance
     Given some role assignments
     When Admin authenticates with nonce = 1 and roles = "user,read_all"
-    When Admin GETs to "/api/account/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
+    When Admin GETs to "/api/balance/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """
@@ -42,11 +42,11 @@ Feature: Accounts endpoint
     }
     """
 
-  Scenario: SuperAdmin role can access another account
+  Scenario: SuperAdmin role can access another balance
     Given some role assignments
     Given a super-admin user (Super)
     When Super authenticates with nonce = 1
-    When Super GETs to "/api/account/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
+    When Super GETs to "/api/balance/14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp" with body
     Then I receive a 200 Ok response
     Then I receive a partial JSON response:
     """

--- a/tari_payment_engine/src/traits/account_management.rs
+++ b/tari_payment_engine/src/traits/account_management.rs
@@ -81,6 +81,10 @@ pub trait AccountManagement {
 
     async fn search_orders(&self, query: OrderQueryFilter) -> Result<Vec<Order>, AccountApiError>;
 
+    /// Creditors are the list of users that have unpaid orders.
+    /// Unapid orders are defined as "New" orders only.
+    /// Unclaimed orders are not considered unpaid (though this definition is somewhat arbitrary and could change in
+    /// future).
     async fn creditors(&self) -> Result<Vec<CustomerOrders>, AccountApiError>;
 
     async fn fetch_customer_ids(&self, pagination: &Pagination) -> Result<Vec<String>, AccountApiError>;

--- a/tari_payment_server/src/endpoint_tests/accounts.rs
+++ b/tari_payment_server/src/endpoint_tests/accounts.rs
@@ -8,7 +8,7 @@ use super::helpers::{get_request, issue_token};
 use crate::{
     auth::JwtClaims,
     endpoint_tests::mocks::MockAccountManager,
-    routes::{AccountRoute, MyAccountRoute},
+    routes::{BalanceRoute, MyBalanceRoute},
 };
 
 #[actix_web::test]
@@ -38,7 +38,7 @@ async fn fetch_my_account_expired_token() {
 fn configure(cfg: &mut ServiceConfig) {
     let account_manager = MockAccountManager::new();
     let accounts_api = AccountApi::new(account_manager);
-    cfg.service(MyAccountRoute::<MockAccountManager>::new())
-        .service(AccountRoute::<MockAccountManager>::new())
+    cfg.service(MyBalanceRoute::<MockAccountManager>::new())
+        .service(BalanceRoute::<MockAccountManager>::new())
         .app_data(web::Data::new(accounts_api));
 }

--- a/tari_payment_server/src/server.rs
+++ b/tari_payment_server/src/server.rs
@@ -32,10 +32,10 @@ use crate::{
     middleware::HmacMiddlewareFactory,
     routes::{
         health,
-        AccountRoute,
         AddAuthorizedWalletRoute,
         AddressesRoute,
         AuthRoute,
+        BalanceRoute,
         CancelOrderRoute,
         CheckTokenRoute,
         ClaimOrderRoute,
@@ -49,7 +49,7 @@ use crate::{
         HistoryForCustomerRoute,
         IncomingPaymentNotificationRoute,
         IssueCreditRoute,
-        MyAccountRoute,
+        MyBalanceRoute,
         MyHistoryRoute,
         MyOrdersRoute,
         MyPaymentsRoute,
@@ -148,8 +148,8 @@ pub fn create_server_instance(
         // Routes that require authentication
         let auth_scope = web::scope("/api")
             .service(UpdateRolesRoute::<SqliteDatabase>::new())
-            .service(MyAccountRoute::<SqliteDatabase>::new())
-            .service(AccountRoute::<SqliteDatabase>::new())
+            .service(BalanceRoute::<SqliteDatabase>::new())
+            .service(MyBalanceRoute::<SqliteDatabase>::new())
             .service(MyHistoryRoute::<SqliteDatabase>::new())
             .service(HistoryForAddressRoute::<SqliteDatabase>::new())
             .service(HistoryForCustomerRoute::<SqliteDatabase>::new())

--- a/taritools/src/interactive/formatting.rs
+++ b/taritools/src/interactive/formatting.rs
@@ -11,7 +11,15 @@ use prettytable::{
 use qrcode::{render::unicode, QrCode};
 use tari_common_types::tari_address::TariAddress;
 use tari_payment_engine::{
-    db_types::{AddressBalance, CustomerBalance, CustomerOrderBalance, Order, Payment, SettlementJournalEntry},
+    db_types::{
+        AddressBalance,
+        CustomerBalance,
+        CustomerOrderBalance,
+        CustomerOrders,
+        Order,
+        Payment,
+        SettlementJournalEntry,
+    },
     order_objects::{ClaimedOrder, OrderResult},
     tpe_api::{
         account_objects::{AddressHistory, CustomerHistory},
@@ -274,6 +282,18 @@ pub fn format_customer_history(history: &CustomerHistory) -> Result<String> {
     writeln!(f, "### Orders\n\n{orders}\n")?;
     let settlements = format_settlements(&history.settlements)?;
     writeln!(f, "### Transactions:\n\n{settlements}\n")?;
+    Ok(f)
+}
+
+pub fn format_customer_orders(orders: &[CustomerOrders]) -> Result<String> {
+    let mut f = String::new();
+    let mut table = Table::new();
+    table.set_titles(row!["Customer ID", "Order status", "Total value"]);
+    orders.iter().for_each(|customer| {
+        table.add_row(row![customer.customer_id, customer.status, customer.total_orders.to_string(),]);
+    });
+    markdown_style(&mut table);
+    writeln!(f, "{table}")?;
     Ok(f)
 }
 

--- a/taritools/src/interactive/menus.rs
+++ b/taritools/src/interactive/menus.rs
@@ -8,8 +8,10 @@ pub type Menu = (&'static str, &'static [&'static str]);
 pub mod commands {
     pub const ADD_AUTH_WALLET: &str = "Add authorized wallet";
     pub const ADD_PROFILE: &str = "Add profile";
+    pub const BALANCE_FOR_ADDRESS: &str = "Balance for Address";
     pub const CANCEL: &str = "Cancel Order";
     pub const CLAIM_ORDER: &str = "Claim Order";
+    pub const CREDITORS: &str = "Get all unpaid orders";
     pub const EDIT_MEMO: &str = "Edit memo";
     pub const EXIT: &str = "Exit";
     pub const FETCH_PRICE: &str = "Fetch Tari price";
@@ -20,8 +22,8 @@ pub mod commands {
     pub const LIST_PAYMENT_ADDRESSES: &str = "List payment addresses";
     pub const LOGOUT: &str = "Logout";
     pub const MARK_ORDER_PAID: &str = "Mark order as Paid";
-    pub const MY_ACCOUNT: &str = "My Account";
     pub const MY_ACCOUNT_HISTORY: &str = "Account History";
+    pub const MY_BALANCE: &str = "My Balance";
     pub const MY_OPEN_ORDERS: &str = "My Open Orders";
     pub const MY_ORDERS: &str = "My Orders";
     pub const MY_PAYMENTS: &str = "My Payments";
@@ -42,7 +44,7 @@ pub use commands::*;
 
 pub const TOP_MENU: [&str; 4] = [NAV_TO_ADMIN_MENU, NAV_TO_USER_MENU, LOGOUT, EXIT];
 
-pub const ADMIN_MENU: [&str; 20] = [
+pub const ADMIN_MENU: [&str; 22] = [
     CANCEL,
     MARK_ORDER_PAID,
     RESET_ORDER,
@@ -51,7 +53,9 @@ pub const ADMIN_MENU: [&str; 20] = [
     LOGOUT,
     NAV_BACK,
     ISSUE_CREDIT,
+    CREDITORS,
     ORDER_BY_ID,
+    BALANCE_FOR_ADDRESS,
     ORDERS_FOR_ADDRESS,
     PAYMENTS_FOR_ADDRESS,
     HISTORY_FOR_ADDRESS,
@@ -68,10 +72,10 @@ pub const ADMIN_MENU: [&str; 20] = [
 pub const USER_MENU: [&str; 11] = [
     ADD_PROFILE,
     CLAIM_ORDER,
-    MY_ACCOUNT,
     LOGOUT,
     NAV_BACK,
     EXIT,
+    MY_BALANCE,
     MY_ORDERS,
     MY_OPEN_ORDERS,
     MY_PAYMENTS,


### PR DESCRIPTION
The account endpoint returns the address balance, so it's better named balance

chore(taritools): rename account to balance
fix: migrate tests

Update tests to use the balance instead of account endpoints.

chore: remove unused menu item

MY_ACCOUNT is deprecated. Use MY_BALANCE instead.