### PR TITLE
feat: allow unclaimed order to be marked as paid

### DIFF
--- a/tari_payment_engine/src/sqlite/db/accounts.rs
+++ b/tari_payment_engine/src/sqlite/db/accounts.rs
@@ -29,6 +29,7 @@ pub(crate) async fn link_address_to_order(
     link_address_to_customer(address, &order.customer_id, conn).await
 }
 
+/// Links an address to a customer id. This function is idempotent due to a uniqueness constraint on the DB table.
 pub(crate) async fn link_address_to_customer(
     address: &TariAddress,
     customer_id: &str,

--- a/tari_payment_engine/src/tpe_api/order_flow_api.rs
+++ b/tari_payment_engine/src/tpe_api/order_flow_api.rs
@@ -279,7 +279,7 @@ where B: PaymentGatewayDatabase
         Ok(())
     }
 
-    /// A manual order status transition from `New` to `Paid` status.
+    /// A manual order status transition from `New`, or `Unclaimed` to `Paid` status.
     /// This method is called by the default implementation of [`modify_status_for_order`] when the new status is
     /// `Paid`. When this happens, the following side effects occur:
     ///
@@ -294,7 +294,7 @@ where B: PaymentGatewayDatabase
             .ok_or_else(|| PaymentGatewayError::OrderNotFound(order_id.clone()))?;
         // We don't call self.issue_credit_note() here because we want to force this specific order to get paid
         // The former lets any valid order be paid once the credit is issued.
-        let updated_order = self.db.mark_new_order_as_paid(order, reason).await?;
+        let updated_order = self.db.mark_new_or_unclaimed_order_as_paid(order, reason).await?;
         if updated_order.status == OrderStatusType::Paid {
             self.call_order_paid_hook(&[updated_order.clone()]).await;
             info!(

--- a/tari_payment_engine/src/traits/payment_gateway_database.rs
+++ b/tari_payment_engine/src/traits/payment_gateway_database.rs
@@ -104,7 +104,11 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
     /// * A credit note for the `total_price` is created,
     /// * The `process_new_payment` flow is triggered, which will cause the order to be fulfilled and the status updated
     ///   to `Paid`.
-    async fn mark_new_order_as_paid(&self, order: Order, reason: &str) -> Result<Order, PaymentGatewayError>;
+    async fn mark_new_or_unclaimed_order_as_paid(
+        &self,
+        order: Order,
+        reason: &str,
+    ) -> Result<Order, PaymentGatewayError>;
 
     /// A manual order status transition from `New` to `Expired` or `Cancelled` status.
     ///


### PR DESCRIPTION
There is definitely a use-case for marking unclaimed orders as paid, for example when a customer does not have a Tari wallet and Admins want their order fulfilled.

The tight restrictions on `mark..as_paid` are lifted to include `Unclaimed` orders.

If an order is unclaimed, the flow is:
- Create credit note payment
- Claim order for credit address
- Process payment