### PR TITLE
feat: accept arbitrary numbers as order ids

### DIFF
--- a/taritools/src/shopify/config.rs
+++ b/taritools/src/shopify/config.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+use tari_payment_server::config::OrderIdField;
+
+/// Examines the environment configuration to determine the field used to determine the order id.
+pub fn order_id_field_from_env() -> OrderIdField {
+    env::var("TPG_ORDER_ID_FIELD")
+        .map(|s| if s.to_lowercase().as_str() == "name" { OrderIdField::Name } else { OrderIdField::Id })
+        .unwrap_or_default()
+}

--- a/taritools/src/shopify/mod.rs
+++ b/taritools/src/shopify/mod.rs
@@ -1,5 +1,7 @@
 mod command_def;
 mod command_handler;
+mod config;
 
 pub use command_def::{OrdersCommand, ShopifyCommand};
 pub use command_handler::handle_shopify_command;
+pub use config::order_id_field_from_env;


### PR DESCRIPTION
If SHOPIFY_ORDER_FIELD is name, the following payment id strings will match to order ids:

| payment id string | order id |
|------------|---------------|
| `12345` | `#12345` |
| `#12345` | `#12345` |
| `#00001` | `#00001` |
| `Order#12345` | `#12345` |
| `Order# 12345` | `#12345` |
| `order#12345` | `#12345` |
| `order 12345` | `#12345` |
| `Order ID is 1234` | `#1234` |
| `Track Order 9876. This is 500` | `#9876` |
| `order 123 456` | `#123` |
| `123 45 67` | `#123` |
| `#5674 Main st` | `#5674` |
| `5674 Main st` | `#5674` |
| `#5674. Phone 555-666-1111` | `#5674` |
| `555-888-9995` | - |
| `phone: 555-888-9995` | - |
| `Order#` | - |