### PR TITLE
fix: default url in taritools

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,7 +14,8 @@ TPG_SHOPIFY_STOREFRONT_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TPG_SHOPIFY_ORDER_ID_FIELD=id
 
 RUST_LOG="error,shopify_payment_gateway=trace"
-
+# Only used in taritools
+TPG_SCHEMA=http
 TPG_HOST=127.0.0.1
 TPG_PORT=4444
 TPG_DATABASE_URL=sqlite://data/tari_store.db


### PR DESCRIPTION
Taritools now uses envars to extract a default URL for the API server in unauthenticated requests