### PR TITLE
feat: unsafe memos

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,6 +21,9 @@ TPG_PORT=4444
 TPG_DATABASE_URL=sqlite://data/tari_store.db
 TPG_SHOPIFY_IP_WHITELIST=
 TPG_DISABLE_WALLET_WHITELIST=0
+# Set TPG_DISABLE_MEMO_SIGNATURE_CHECK=1 to disable the memo signature check. This will accept order numbers
+# in memo fields of interactive transactions without checking the signature. Setting this to 1 is not recommended.
+TPG_DISABLE_MEMO_SIGNATURE_CHECK=0
 TPG_USE_X_FORWARDED_FOR=0
 TPG_USE_FORWARDED=0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "e2e"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3680,7 +3680,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shopify_tools"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "graphql-parser",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "tari_payment_engine"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "blake2",
  "chrono",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "tari_payment_server"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "actix-http",
  "actix-jwt-auth-middleware",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "taritools"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4775,7 +4775,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tpg_common"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "serde",
  "sqlx",

--- a/e2e/tests/cucumber/setup.rs
+++ b/e2e/tests/cucumber/setup.rs
@@ -274,6 +274,7 @@ async fn server_configuration(world: &mut TPGWorld, step: &Step) {
             "use_x_forwarded_for" => world.config.use_x_forwarded_for = value == "true",
             "use_forwarded" => world.config.use_forwarded = value == "true",
             "disable_wallet_whitelist" => world.config.disable_wallet_whitelist = value == "true",
+            "disable_memo_signature_check" => world.config.disable_memo_signature_check = value == "true",
             "order_id_field" => {
                 world.config.shopify_config.order_id_field =
                     if value == "name" { OrderIdField::Name } else { OrderIdField::Id }

--- a/e2e/tests/cucumber/world.rs
+++ b/e2e/tests/cucumber/world.rs
@@ -52,6 +52,7 @@ impl Default for TPGWorld {
             use_x_forwarded_for: false,
             use_forwarded: false,
             disable_wallet_whitelist: false,
+            disable_memo_signature_check: false,
             unclaimed_order_timeout: Duration::seconds(2),
             unpaid_order_timeout: Duration::seconds(4),
             shopify_config: Default::default(),

--- a/e2e/tests/features/order_matching_with_raw_memo.feature
+++ b/e2e/tests/features/order_matching_with_raw_memo.feature
@@ -1,0 +1,46 @@
+@memo_signature_disable
+Feature: Order id using order name
+  Background:
+    Given a server configuration
+      | use_x_forwarded_for          | true |
+      | order_id_field               | name |
+      | disable_memo_signature_check | true |
+    Given a blank slate
+    Given an authorized wallet with secret df158b8389c68aac01a91276b742d2527f951d3c7289e4ccdecfa0672947270e
+    """
+      {
+        "address": "14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "ip_address": "192.168.1.100"
+      }
+    """
+
+  Scenario: Alice: Pay with payment_id -> Confirm -> Order. The order is fulfilled.
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {"payment": {
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+      "amount":2500000000,
+      "txid":"payment001",
+      "memo": "order #12345"
+    },
+    "auth": {
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+      "nonce":1,
+      "signature":"8e3b91d09b4118053af3cd1ed508cf8771cfcad86712e6ff1c38f6cafcb8954c532af250c3a8d5d990f0af66af5372325e5dac08b14f2ec0a643df96060f3300"
+    }}
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "confirmation": {"txid": "payment001"},
+      "auth": {
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "nonce":2,
+        "signature":"16729e3c9b08022a16edfa0bf2e1cfc1d8dadd5e6387b4fd76005ac8a20c0f53087434524748981e9c61f9b7ce122fdf1a45299b132cd4495b19b7d1208cea01"
+      }
+    }
+    """
+    When Customer #1 ["alice"] places order with name "#12345" for 2400 XTR
+    Then order "#12345" is in state Paid
+    And account for customer 1 has a current balance of 100 XTR
+

--- a/tari_payment_engine/src/helpers/mod.rs
+++ b/tari_payment_engine/src/helpers/mod.rs
@@ -4,6 +4,11 @@ mod wallet_signature;
 // All other helpers get thrown in here
 mod gumbo;
 
-pub use gumbo::{create_dummy_address_for_cust_id, get_payment_wallet_address};
+pub use gumbo::{
+    create_dummy_address_for_cust_id,
+    extract_order_id_from_str,
+    get_payment_wallet_address,
+    is_forbidden_pattern,
+};
 pub use memo_signature::{extract_and_verify_memo_signature, MemoSignature, MemoSignatureError};
 pub use wallet_signature::{WalletSignature, WalletSignatureError};

--- a/tari_payment_server/src/config.rs
+++ b/tari_payment_server/src/config.rs
@@ -39,6 +39,9 @@ pub struct ServerConfig {
     pub use_forwarded: bool,
     /// If true, the server will not validate payment API calls against a whitelist of wallet addresses. **DANGER**
     pub disable_wallet_whitelist: bool,
+    /// If true, the server will not require signed messages in memo fields, but will accept naked order ids.
+    /// **DANGER**
+    pub disable_memo_signature_check: bool,
     /// The time before an unclaimed order is considered abandoned and marked as expired.
     pub unclaimed_order_timeout: Duration,
     /// The time before an unpaid order is considered expired and marked as such.
@@ -74,6 +77,7 @@ impl Default for ServerConfig {
             use_x_forwarded_for: false,
             use_forwarded: false,
             disable_wallet_whitelist: false,
+            disable_memo_signature_check: false,
             unclaimed_order_timeout: DEFAULT_UNCLAIMED_ORDER_TIMEOUT,
             unpaid_order_timeout: DEFAULT_UNPAID_ORDER_TIMEOUT,
             shopify_config: ShopifyConfig::default(),
@@ -127,6 +131,8 @@ impl ServerConfig {
         let use_forwarded = env::var("TPG_USE_FORWARDED").map(|s| &s == "1" || &s == "true").is_ok();
         let disable_wallet_whitelist =
             env::var("TPG_DISABLE_WALLET_WHITELIST").map(|s| &s == "1" || &s == "true").is_ok();
+        let disable_memo_signature_check =
+            env::var("TPG_DISABLE_MEMO_SIGNATURE_CHECK").map(|s| &s == "1" || &s == "true").is_ok();
         let (unclaimed_order_timeout, unpaid_order_timeout) = configure_order_timeouts();
         Self {
             host,
@@ -137,6 +143,7 @@ impl ServerConfig {
             use_forwarded,
             use_x_forwarded_for,
             disable_wallet_whitelist,
+            disable_memo_signature_check,
             unclaimed_order_timeout,
             unpaid_order_timeout,
         }
@@ -333,6 +340,8 @@ pub struct ProxyConfig {
     pub use_x_forwarded_for: bool,
     pub use_forwarded: bool,
     pub disable_wallet_whitelist: bool,
+    pub disable_memo_signature_check: bool,
+    pub shopify_order_field: OrderIdField,
 }
 
 impl ProxyConfig {
@@ -341,6 +350,8 @@ impl ProxyConfig {
             use_x_forwarded_for: config.use_x_forwarded_for,
             use_forwarded: config.use_forwarded,
             disable_wallet_whitelist: config.disable_wallet_whitelist,
+            disable_memo_signature_check: config.disable_memo_signature_check,
+            shopify_order_field: config.shopify_config.order_id_field,
         }
     }
 }

--- a/tari_payment_server/src/helpers.rs
+++ b/tari_payment_server/src/helpers.rs
@@ -6,6 +6,12 @@ use hmac::{Hmac, Mac};
 use log::{debug, trace};
 use regex::Regex;
 use sha2::Sha256;
+use tari_payment_engine::{
+    db_types::{NewPayment, OrderId},
+    helpers::{extract_order_id_from_str, MemoSignature},
+};
+
+use crate::config::OrderIdField;
 
 /// Get the remote IP address from the request. It uses 3 sources to determine the IP address, in decreasing order
 /// of preference:
@@ -55,8 +61,53 @@ pub fn calculate_hmac(secret: &str, data: &[u8]) -> String {
     encode(code_bytes)
 }
 
+/// Tries to extract the order number from the memo.
+///
+/// If the memo is not present, return None.
+/// If an order is successfully extracted, return `Some(true)`, otherwise `Some(false)`.
+///
+/// Otherwise, if `require_signature` is true, the memo must contain a valid `MemoSignature` object:
+///   1. The memo bust be a valid JSON object.
+///   2. The `claim` field must be present.
+///   3. The `claim` field must be a valid JSON object containing a valid `MemoSignature`.
+///
+/// If `require_signature` is false, the first number encountered in the memo is used as the order number.
+/// If orderIdField is `OrderIdField::Name`, the number will be prefixed with a `#`.
+pub fn try_extract_order_id(
+    payment: &mut NewPayment,
+    require_signature: bool,
+    order_id_field: OrderIdField,
+) -> Option<bool> {
+    payment.memo.as_ref().map(|m| match serde_json::from_str::<MemoSignature>(m) {
+        Ok(m) => {
+            let result = m.is_valid();
+            if result {
+                payment.order_id = Some(OrderId::new(m.order_id));
+            }
+            result
+        },
+        Err(_) if require_signature => false,
+        Err(_) => {
+            let prefix = match order_id_field {
+                OrderIdField::Id => "",
+                OrderIdField::Name => "#",
+            };
+            if let Some(order_id) = extract_order_id_from_str(m, prefix) {
+                payment.order_id = Some(order_id);
+                true
+            } else {
+                false
+            }
+        },
+    })
+}
+
 #[cfg(test)]
 mod test {
+    use serde_json::json;
+    use tari_common_types::tari_address::TariAddress;
+    use tpg_common::MicroTari;
+
     use super::*;
 
     #[test]
@@ -64,5 +115,57 @@ mod test {
         let data = r#"{"id":5621189509332,..."source":"shopify"}"#;
         let hmac = calculate_hmac("my_secret", data.as_bytes());
         assert_eq!(hmac, "1JKXEbaNTtaw8EyjOKhDEJL/hE/SKH1ZZADWGD36m6k=")
+    }
+
+    #[test]
+    fn extract_order_id_with_signature() {
+        let mut payment = NewPayment::new(
+            TariAddress::from_str("14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY").unwrap(),
+            MicroTari::from_tari(100),
+            "txid111111".to_string(),
+        );
+        payment.with_memo(json!({
+            "address": "14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY",
+            "order_id": "oid554432",
+            "signature": "74236918f5815383ad7a889fa2c26037418b217f983575b5b5cfde21c7bcf3094ca6ff09c43fca8d4040a38e60b57fea622d5919979fae4ccfea93883df6bd00"
+            }).to_string()
+        );
+        let result = try_extract_order_id(&mut payment, true, OrderIdField::Id);
+        assert!(matches!(result, Some(true)));
+        assert_eq!(payment.order_id.unwrap().as_str(), "oid554432");
+    }
+
+    #[test]
+    fn extract_order_id_with_invalid_signature() {
+        let mut payment = NewPayment::new(
+            TariAddress::from_str("14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY").unwrap(),
+            MicroTari::from_tari(100),
+            "txid111111".to_string(),
+        );
+        payment.with_memo(json!({
+            "address": "14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY",
+            "order_id": "oid554432",
+            "signature": "00000018f5815383ad7a889fa2c26037418b217f983575b5b5cfde21c7bcf3094ca6ff09c43fca8d4040a38e60b57fea622d5919979fae4ccfea93883df6bd00"
+            }).to_string()
+        );
+        let result = try_extract_order_id(&mut payment, true, OrderIdField::Id);
+        assert!(matches!(result, Some(false)));
+        assert!(payment.order_id.is_none());
+    }
+
+    #[test]
+    fn extract_order_id_with_raw_memo() {
+        let mut payment = NewPayment::new(
+            TariAddress::from_str("14s9vDTwrweZvWEgQ9gNhXXPX68DPXSSAHNFWYEPi5JsBQY").unwrap(),
+            MicroTari::from_tari(100),
+            "txid111111".to_string(),
+        );
+        payment.with_memo("order #12345");
+        let result = try_extract_order_id(&mut payment, false, OrderIdField::Name);
+        assert!(matches!(result, Some(true)));
+        assert_eq!(payment.order_id.as_ref().unwrap().as_str(), "#12345");
+        let result = try_extract_order_id(&mut payment, false, OrderIdField::Id);
+        assert!(matches!(result, Some(true)));
+        assert_eq!(payment.order_id.unwrap().as_str(), "12345");
     }
 }


### PR DESCRIPTION
This feature adds a new configuration variable,
TPG_DISABLE_MEMO_SIGNATURE_CHECK, which if enabled via `TPG_DISABLE_MEMO_SIGNATURE_CHECK=1` will not require the memo field for interactive payments to have be a MemoSignature attesting to the order id.

In general, setting this flag may lead to spoofing attacks and is discouraged, but it is added as a convenience for wallets that do not want to add a call to create a signed memo field.