### PR TITLE
feat: accept alternative order ids

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,7 @@ TPG_SHOPIFY_HMAC_SECRET=xxxxxxxxxxxxxxxxxxxx
 TPG_SHOPIFY_HMAC_CHECKS=1
 TPG_SHOPIFY_ADMIN_ACCESS_TOKEN=shpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TPG_SHOPIFY_STOREFRONT_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TPG_STRICT_MODE=1
 TPG_SHOPIFY_ORDER_ID_FIELD=id
 
 RUST_LOG="error,shopify_payment_gateway=trace"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "arc-swap"
@@ -639,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -937,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "e2e"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -2053,9 +2053,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.2"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
+checksum = "bc144d44a31d753b02ce64093d532f55ff8dc4ebf2ffb8a63c0dda691385acae"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -2200,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "impl-more"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
+checksum = "aae21c3177a27788957044151cc2800043d127acaa460a47ebb9b84dfa2c6aa0"
 
 [[package]]
 name = "impl-serde"
@@ -2402,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
@@ -2792,9 +2792,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -2824,9 +2824,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -3157,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3435,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -3590,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "67d42a0bd4ac281beff598909bb56a86acaf979b84483e1c79c10dcaf98f8cf3"
 dependencies = [
  "itoa",
  "memchr",
@@ -3680,7 +3680,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shopify_tools"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "graphql-parser",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "tari_payment_engine"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "blake2",
  "chrono",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "tari_payment_server"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "actix-http",
  "actix-jwt-auth-middleware",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "taritools"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4775,7 +4775,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tpg_common"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "serde",
  "sqlx",

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -91,6 +91,7 @@ Storefront environment variables are explained in the relevant storefront integr
 - `TPG_DATABASE_URL`: This variable is used to set the URL for the TPG database. If not set, an error message will be 
   logged, and the value will be set to an empty string.
   It's of the form `sqlite://<path to database file>` or `postgres://<username>:<password>@<host>/<database>`.
+- `TPG_STRICT_MODE`: Enable strict mode. When `1` or `true`, _only_ the order_id field will be used to identify orders.
 
 **Do:** Set `TPG_PAYMENT_WALLET_ADDRESS` to the public key of the wallet that will receive payments. 
 This key must be present in the Authorized Wallet list in the database. (Note: This envar will be deprecated in future)

--- a/e2e/tests/cucumber/setup.rs
+++ b/e2e/tests/cucumber/setup.rs
@@ -23,6 +23,7 @@ fn seed_orders() -> [NewOrder; 5] {
     [
         NewOrder {
             order_id: OrderId::new("1"),
+            alt_order_id: Some(OrderId::new("#1")),
             currency: "XTR".into(),
             customer_id: "alice".into(),
             memo: Some("Manually inserted by Keith".into()),
@@ -33,6 +34,7 @@ fn seed_orders() -> [NewOrder; 5] {
         },
         NewOrder {
             order_id: OrderId::new("2"),
+            alt_order_id: Some(OrderId::new("#2")),
             currency: "XTR".into(),
             customer_id: "bob".into(),
             memo: Some("Manually inserted by Charlie".into()),
@@ -43,6 +45,7 @@ fn seed_orders() -> [NewOrder; 5] {
         },
         NewOrder {
             order_id: OrderId::new("3"),
+            alt_order_id: Some(OrderId::new("#3")),
             currency: "XTR".into(),
             customer_id: "alice".into(),
             memo: Some("Manually inserted by Sam".into()),
@@ -53,6 +56,7 @@ fn seed_orders() -> [NewOrder; 5] {
         },
         NewOrder {
             order_id: OrderId::new("4"),
+            alt_order_id: Some(OrderId::new("#4")),
             currency: "XTR".into(),
             customer_id: "bob".into(),
             memo: Some("Manually inserted by Ray".into()),
@@ -63,6 +67,7 @@ fn seed_orders() -> [NewOrder; 5] {
         },
         NewOrder {
             order_id: OrderId::new("5"),
+            alt_order_id: Some(OrderId::new("#5")),
             currency: "XMR".into(),
             customer_id: "admin".into(),
             memo: Some("Manually inserted by Charlie".into()),
@@ -195,7 +200,7 @@ async fn fresh_database(world: &mut TPGWorld) {
         let id = order.order_id.clone();
         let address = order.address.as_ref().unwrap().clone();
         db.insert_order(order).await.unwrap();
-        db.claim_order(&id, &address).await.unwrap();
+        db.claim_order(&id, &address, true).await.unwrap();
     }
     world.start_server().await;
 }
@@ -204,7 +209,7 @@ async fn fresh_database(world: &mut TPGWorld) {
 async fn payments_received(world: &mut TPGWorld) {
     let db = world.database();
     for payment in seed_payments() {
-        db.process_new_payment(payment).await.expect("Error persisting payment");
+        db.process_new_payment(payment, true).await.expect("Error persisting payment");
     }
 }
 
@@ -279,6 +284,7 @@ async fn server_configuration(world: &mut TPGWorld, step: &Step) {
                 world.config.shopify_config.order_id_field =
                     if value == "name" { OrderIdField::Name } else { OrderIdField::Id }
             },
+            "strict_mode" => world.config.strict_mode = value == "true",
             _ => warn!("Unknown configuration key: {key}"),
         }
     });

--- a/e2e/tests/cucumber/world.rs
+++ b/e2e/tests/cucumber/world.rs
@@ -56,6 +56,7 @@ impl Default for TPGWorld {
             unclaimed_order_timeout: Duration::seconds(2),
             unpaid_order_timeout: Duration::seconds(4),
             shopify_config: Default::default(),
+            strict_mode: true,
         };
         Self {
             config,

--- a/e2e/tests/features/order_matching_with_name.feature
+++ b/e2e/tests/features/order_matching_with_name.feature
@@ -3,12 +3,13 @@ Feature: Order id using order name
   Background:
     Given a server configuration
       | use_x_forwarded_for | true   |
-      | order_id_field      | name |
+      | order_id_field      | name   |
+      | strict_mode         | true   |
     Given a blank slate
 
   Scenario: The server can be configured to user the name field to id orders.
     When Customer #1 ["alice"] places order with name "alice001" for 2400 XTR
     Then customer id 1 has current orders worth 2400 XTR
     And account for customer 1 has a current balance of 0 XTR
-    And order "alice001" is in state Unclaimed
+    And order "id-alice001" is in state Unclaimed
 

--- a/e2e/tests/features/order_matching_with_raw_memo.feature
+++ b/e2e/tests/features/order_matching_with_raw_memo.feature
@@ -3,7 +3,7 @@ Feature: Order id using order name
   Background:
     Given a server configuration
       | use_x_forwarded_for          | true |
-      | order_id_field               | name |
+      | order_id_field               | id   |
       | disable_memo_signature_check | true |
     Given a blank slate
     Given an authorized wallet with secret df158b8389c68aac01a91276b742d2527f951d3c7289e4ccdecfa0672947270e
@@ -40,7 +40,7 @@ Feature: Order id using order name
       }
     }
     """
-    When Customer #1 ["alice"] places order with name "#12345" for 2400 XTR
-    Then order "#12345" is in state Paid
+    When Customer #1 ["alice"] places order "12345" for 2400 XTR, with memo
+    Then order "12345" is in state Paid
     And account for customer 1 has a current balance of 100 XTR
 

--- a/e2e/tests/features/order_payment_matching_with_strict_mode_off.feature
+++ b/e2e/tests/features/order_payment_matching_with_strict_mode_off.feature
@@ -1,0 +1,382 @@
+@no_strict
+Feature: Order Fulfillment with strict mode off
+  Background:
+    Given a server configuration
+      | use_x_forwarded_for          | true  |
+      | order_id_field               | name  |
+      | disable_memo_signature_check | true  |
+      | strict_mode                  | false |
+    Given a blank slate
+    Given an authorized wallet with secret df158b8389c68aac01a91276b742d2527f951d3c7289e4ccdecfa0672947270e
+    """
+      {
+        "address": "14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "ip_address": "192.168.1.100"
+      }
+    """
+
+  Scenario: Alice: Order -> Pay -> Confirm. The order is fulfilled.
+    When Customer #1 ["alice"] places order with name "#1000" for 2400 XTR
+    Then customer id 1 has current orders worth 2400 XTR
+    And account for customer 1 has a current balance of 0 XTR
+    And order "id-#1000" is in state Unclaimed
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {
+      "payment": {
+         "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+         "amount":2500000000,
+         "txid":"payment001",
+         "memo": "order 1000"
+      },
+      "auth": {"address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":1,"signature":"ac509cfdb1915e572faf9fb5c29ee5ab364f177f352f36a8f8b50ab48f34374961103694fea123f30a1e0ec66321186b6c3ead8e5cedf88c64e3256c1610fb03"}
+    }
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    # Transaction is not confirmed yet
+    Then order "id-#1000" is in state New
+    And account for customer 1 has a current balance of 0 XTR
+    And User Alice has a pending balance of 2500 XTR
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "confirmation": {"txid": "payment001"},
+      "auth": {
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "nonce":2,
+        "signature":"16729e3c9b08022a16edfa0bf2e1cfc1d8dadd5e6387b4fd76005ac8a20c0f53087434524748981e9c61f9b7ce122fdf1a45299b132cd4495b19b7d1208cea01"
+      }
+    }
+    """
+    Then order "id-#1000" is in state Paid
+    And account for customer 1 has a current balance of 100 XTR
+    And the OrderPaid trigger fires with
+    """
+    {
+      "order": {
+      "order_id": "id-#1000",
+      "alt_id": "#1000",
+      "customer_id": "1",
+      "total_price": 2400000000,
+      "currency": "XTR",
+      "id": 1,
+      "status": "Paid"
+    }
+   }
+   """
+
+  Scenario: Alice: Pay -> Confirm -> Order. The order is fulfilled
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {"payment": {
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+      "amount":2500000000,
+      "txid":"payment001",
+      "order_id": "#1001"
+    },
+    "auth": {"address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":1,"signature":"50d3560c49a9a53ab6dcb094ef647770b457aff5876ad2792df669d7bac40a11089523951e32e5e0134e50917cfa4b49dab1191e73bfe75eb5814d8ffe063009"}
+    }
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    And account for customer 1 has a current balance of 0 XTR
+    And User Alice has a pending balance of 2500 XTR
+    And the PaymentReceived trigger fires with
+    """
+      {
+        "payment": {
+          "sender": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+          "txid": "payment001",
+          "amount": 2500000000,
+          "status": "received"
+        }
+      }
+    """
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "confirmation": {"txid": "payment001"},
+      "auth": {
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "nonce":2,
+        "signature":"3a9edfc5d607943e78557bf220c199486b4cb1964dee2e5be5c3173c40e4e1684131ec88b317a61ea0574b3cbb8ffdec6bb5f4937067b445eabdc3e15121a003"
+      }
+    }
+    """
+    Then address 14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt has a current balance of 2500 XTR
+    And the PaymentConfirmed trigger fires with
+    """
+      {
+        "payment": {
+          "sender": "14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+          "txid": "payment001",
+          "amount": 2500000000,
+          "status": "confirmed"
+        }
+      }
+    """
+    When Customer #1 ["alice"] places order with name "#1001" for 2400 XTR
+    Then customer id 1 has paid orders worth 2400 XTR
+    And account for customer 1 has a current balance of 100 XTR
+    And order "id-#1001" is in state Paid
+    And the OrderPaid trigger fires with
+    """
+    {
+      "order": {
+        "order_id": "id-#1001",
+        "alt_id": "#1001",
+        "customer_id": "1",
+        "total_price": 2400000000,
+        "currency": "XTR",
+        "id": 1,
+        "status": "Paid"
+      }
+    }
+    """
+
+  Scenario: Multiple concurrent customers and payments
+    When Customer #1 ["alice"] places order with name "#1000" for 2400 XTR
+    When Customer #2 ["bob"] places order with name "#2000" for 700 XTR
+    # Get a payment from an unknown user
+    # Secret key: 0148217c5dd247c6ccb511c3548cc8b6b5075cbae85f4c3743073fc51a6d8301
+    # Address: 148pD3w44RtpDZ63RxzJoaCJYSUUEpfpFLyacw1qzAgLmo7
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+     {
+       "auth": {
+         "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+         "nonce":1,
+         "signature":"72e1a01b1f8850c55f15898c1b7d0adc6c57764ab67da65081645a0015da4465e7dba7f4308ec5881b85b09f4e2065aab9652898303c652593770ee03e86cb06"
+       },
+       "payment": {
+         "sender":"148pD3w44RtpDZ63RxzJoaCJYSUUEpfpFLyacw1qzAgLmo7",
+         "amount":85000000,
+         "txid":"a7o844001"
+       }
+     }
+    """
+    # Bob pays, but not enough to cover the order
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    { "auth": {"address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":2,"signature":"58b7db039c121177607ace2c48a5678a7a662e0feeb9044e830c608426a108728737ef15800399b99c66afc3f677ed0048333041221562b0cfad77715708fd0d"},
+    "payment": {
+      "sender":"14XubwVbMhtp18SHrjfVKk7TRCx2yk7gZBbsjTPRWCXkCEp",
+      "amount":400000000,
+      "txid":"ab34cd56ef90",
+      "memo": "#2000"
+      }
+    }
+    """
+    # Confirm the 2 payments
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "auth": {
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":3,
+      "signature":"9ede42f17279ad27683c5bfcfca4f0eb28227bc411811629a9669c681985f255728bc81799546289591020ebb854c7564014249ed3f62cb8b8222334e8ff1f00"
+      }, "confirmation": {"txid":"ab34cd56ef90"}
+    }
+    """
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "auth": {
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":4,
+      "signature":"5c8eb63b074d27fe2d75d7eb52613b177b4ca39ec2247d95b0ae71446638544e0ed4a952505e21913f74ea0bdf4396d5a2a60ca359b2889ceccf324c38f39d0b"
+      }, "confirmation": {"txid":"a7o844001"}
+    }
+    """
+    Then account for customer 2 has a current balance of 400 XTR
+    And order "id-#2000" is in state New
+    When Customer #3 ["anon"] places order "id-#3000" for 84 XTR, with memo
+    """
+    {
+      "address":"148pD3w44RtpDZ63RxzJoaCJYSUUEpfpFLyacw1qzAgLmo7",
+      "order_id":"id-#3000",
+      "signature":"8aaeed3e937ccf02b2de789e29675bc11337d783eefd6c8eb3146edf0d92fc11c4871243fcd452a0856b4bf2260e8f10c2ded5b0a5b6cd16306d2ce9d6e8a30f"
+    }
+    """
+    Then account for customer 3 has a current balance of 1 XTR
+    And order "id-#3000" is in state Paid
+    When Customer #1 ["alice"] places order with name "#1002" for 3600 XTR
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {
+    "auth": {"address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":5,"signature":"b81ad88852625658424b03c3268c9c5432748991eeb2b468931adcca321bdc1a5e6b2e63a2afe3b87a1e0453900664fd3945c4ef79e2edc57c8de4e58a1b0807"},
+    "payment": {
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+      "amount":6042000000,
+      "txid":"alicebigpayment",
+      "memo": "Order number 1002"
+      }
+    }
+    """
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "auth": {
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":6,
+      "signature":"84b80c5f052c7b1d30613bc5ac7772b75d319252ed338c50b87cd77281780471384044b7f7ecfed1ec19c7dc1e49553f86121bfcd682d88926b588f9639e360a"
+      }, "confirmation": {"txid":"alicebigpayment"}
+    }
+    """
+    Then account for customer 1 has a current balance of 42 XTR
+    And order "id-#1002" is in state Paid
+    And order "id-#1000" is in state Paid
+
+  Scenario: Order -> Pay with memo-> Confirm. The order is fulfilled.
+    When Customer #1 ["alice"] places order with name "#1005" for 2100 XTR
+    Then customer id 1 has current orders worth 2100 XTR
+    And account for customer 1 has a current balance of 0 XTR
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {"payment": {
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+      "amount":2500000000,
+      "txid":"payment001",
+      "memo": "order #1005"
+    },
+    "auth": {"address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":1,"signature":"8affc83552884fc42d56600cde08bde1df4fa2759b430d8c9a02af666c34342f6856014c01c2618b1cef7a75cfacf3013b46600e2b63d227e5be2fe704441307"}
+    }
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "confirmation": {"txid": "payment001"},
+      "auth": {
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "nonce":2,
+        "signature":"16729e3c9b08022a16edfa0bf2e1cfc1d8dadd5e6387b4fd76005ac8a20c0f53087434524748981e9c61f9b7ce122fdf1a45299b132cd4495b19b7d1208cea01"
+      }
+    }
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    And order "id-#1005" is in state Paid
+    And customer id 1 has current orders worth 0 XTR
+    And account for customer 1 has a current balance of 400 XTR
+
+  Scenario: Order -> Pay -> Confirm -> Claim. The order is fulfilled.
+    When Customer #1 ["alice"] places order with name "#1006" for 2100 XTR
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {"payment": {
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+      "amount":2500000000,
+      "txid":"payment001"
+    },
+    "auth": {
+      "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+      "nonce":1,
+      "signature":"5ed91d58e589bea2f2291155b78005b48a789c3018fdf528f6f4052b2428e532953aa065e08ef91575a610b2ebcf88e63fbf2e21bfd0e8b90b778c16ffc2740e"
+    }}
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "confirmation": {"txid": "payment001"},
+      "auth": {
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "nonce":2,
+        "signature":"16729e3c9b08022a16edfa0bf2e1cfc1d8dadd5e6387b4fd76005ac8a20c0f53087434524748981e9c61f9b7ce122fdf1a45299b132cd4495b19b7d1208cea01"
+      }
+    }
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    And order "id-#1006" is in state Unclaimed
+
+    When User POSTs to "/order/claim" with body
+    """
+    {
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+      "order_id":"#1006",
+      "signature":"02d4bc50a2b12de784652b3d90b82e83f167e44eae78e85d4408ac3731bcab1dd44b7edce6095e16647720977d3bb0326fec38c901a324700645c32b930dcd0b"
+    }
+    """
+    Then order "id-#1006" is in state Paid
+    And account for customer 1 has a current balance of 400 XTR
+
+  Scenario: Pay -> Order -> Claim -> Confirm. The order is fulfilled.
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {"payment": {
+      "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+      "amount":2500000000,
+      "txid":"payment001"
+    },
+    "auth": {"address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":1,"signature":"ba354b7825785f94b38217a0ec5ecb243c3745b2067cd3519c251bbc0645355995b8c7249b2a003ba8c3ef9d4bfef4b1dc116ea43c56a978873fa7ef39ac5e09"}
+    }
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    When Customer #1 ["alice"] places order with name "#1006" for 2100 XTR
+    When User POSTs to "/order/claim" with body
+    """
+    {
+      "address":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+      "order_id":"#1006",
+      "signature":"02d4bc50a2b12de784652b3d90b82e83f167e44eae78e85d4408ac3731bcab1dd44b7edce6095e16647720977d3bb0326fec38c901a324700645c32b930dcd0b"
+    }
+    """
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "confirmation": {"txid": "payment001"},
+      "auth": {
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "nonce":2,
+        "signature":"16729e3c9b08022a16edfa0bf2e1cfc1d8dadd5e6387b4fd76005ac8a20c0f53087434524748981e9c61f9b7ce122fdf1a45299b132cd4495b19b7d1208cea01"
+      }
+    }
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    Then order "id-#1006" is in state Paid
+    And account for customer 1 has a current balance of 400 XTR
+    And account for customer 2 has a current balance of 0 XTR
+
+  Scenario: Alice: Order -> Pay with payment_id -> Confirm. The order is fulfilled.
+    When Customer #1 ["alice"] places order with name "#1007" for 2100 XTR
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {
+      "payment": {
+        "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+        "amount":2500000000,
+        "txid":"payment001",
+        "memo": "order#: 1007"
+      },
+      "auth": {"address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":1,"signature":"3cf7d80eed2a7ff3895d599fe7dc12670a1d1b928d3e6f364f73b435e32791056984f41cd1ffccf3aadf113f72848b152e77ecbeb1cb708eb50cd4f951a8e309"}
+    }
+    """
+    Then order "id-#1007" is in state New
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "confirmation": {"txid": "payment001"},
+      "auth": {
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "nonce":2,
+        "signature":"16729e3c9b08022a16edfa0bf2e1cfc1d8dadd5e6387b4fd76005ac8a20c0f53087434524748981e9c61f9b7ce122fdf1a45299b132cd4495b19b7d1208cea01"
+      }
+    }
+    """
+    Then order "id-#1007" is in state Paid
+    And account for customer 1 has a current balance of 400 XTR
+
+  Scenario: Alice: Pay with payment_id -> Confirm -> Order. The order is fulfilled.
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {
+      "payment": {
+        "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+        "amount":2500000000,
+        "txid":"payment001",
+        "order_id": "#1008"
+      },
+      "auth": {"address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":1,"signature":"4ece42f239f2f9340d2ccb38298103df4ecc6cf8e753b1c29d25daab57950866b0ff9260e38ff08f13f05dce332632eb554bac31265f2baebf50a82427c32d09"}
+    }
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "confirmation": {"txid": "payment001"},
+      "auth": {
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "nonce":2,
+        "signature":"16729e3c9b08022a16edfa0bf2e1cfc1d8dadd5e6387b4fd76005ac8a20c0f53087434524748981e9c61f9b7ce122fdf1a45299b132cd4495b19b7d1208cea01"
+      }
+    }
+    """
+    When Customer #1 ["alice"] places order with name "#1008" for 2100 XTR
+    Then order "id-#1008" is in state Paid
+    And account for customer 1 has a current balance of 400 XTR

--- a/tari_payment_engine/src/db_types.rs
+++ b/tari_payment_engine/src/db_types.rs
@@ -241,6 +241,7 @@ pub struct OrderStatus {
 pub struct Order {
     pub id: i64,
     pub order_id: OrderId,
+    pub alt_id: Option<OrderId>,
     pub customer_id: String,
     pub memo: Option<String>,
     pub total_price: MicroTari,
@@ -267,6 +268,8 @@ impl Eq for Order {}
 pub struct NewOrder {
     /// The order_id as assigned by Shopify
     pub order_id: OrderId,
+    /// An alternative order_id that can be used to reference the order
+    pub alt_order_id: Option<OrderId>,
     /// The customer_id as assigned by Shopify
     pub customer_id: String,
     /// An optional description supplied by the user for the order. Useful for matching orders with payments
@@ -287,6 +290,7 @@ impl NewOrder {
     pub fn new(order_id: OrderId, customer_id: String, total_price: MicroTari) -> Self {
         Self {
             order_id,
+            alt_order_id: None,
             customer_id,
             memo: None,
             total_price,
@@ -307,6 +311,7 @@ impl NewOrder {
 
     pub fn is_equivalent(&self, order: &Order) -> bool {
         self.order_id == order.order_id &&
+            self.alt_order_id == order.alt_id &&
             self.customer_id == order.customer_id &&
             self.memo == order.memo &&
             self.total_price == order.total_price &&
@@ -317,9 +322,13 @@ impl NewOrder {
 
 impl Display for NewOrder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let alt_str = match &self.alt_order_id {
+            Some(alt) => format!(" ({alt})"),
+            None => "".to_string(),
+        };
         write!(
             f,
-            "Order #{order_id} @ \"{customer_id}\". {total_price} ({created_at})",
+            "Order {order_id}{alt_str} @ \"{customer_id}\". {total_price} ({created_at})",
             order_id = self.order_id,
             customer_id = self.customer_id,
             total_price = self.total_price,

--- a/tari_payment_engine/src/sqlite/db/accounts.rs
+++ b/tari_payment_engine/src/sqlite/db/accounts.rs
@@ -130,6 +130,7 @@ pub(crate) async fn orders_for_address(
     SELECT
         orders.id as id,
         orders.order_id as order_id,
+        orders.alt_d as alt_id,
         orders.customer_id as customer_id,
         orders.memo as memo,
         orders.total_price as total_price,

--- a/tari_payment_engine/src/sqlite/db/accounts.rs
+++ b/tari_payment_engine/src/sqlite/db/accounts.rs
@@ -47,18 +47,22 @@ pub(crate) async fn balances_for_customer_id(
 
 pub(crate) async fn balances_for_order_id(
     order_id: &OrderId,
+    alt_id: Option<&OrderId>,
     conn: &mut SqliteConnection,
 ) -> Result<Vec<AddressBalance>, AccountApiError> {
-    let addresses: Vec<AddressBalance> = sqlx::query_as(
-        r#"
-    SELECT * FROM address_balance
-    WHERE address in (SELECT sender from payments WHERE order_id = $1)
-    ORDER BY last_update DESC
-    "#,
-    )
-    .bind(order_id.as_str())
-    .fetch_all(conn)
-    .await?;
+    let where_clause = match alt_id {
+        None => "order_id = $1",
+        Some(_) => "order_id = $1 OR order_id = $2",
+    };
+    let q_str = format!(
+        "SELECT * FROM address_balance WHERE address in (SELECT sender from payments WHERE {where_clause}) ORDER BY \
+         last_update DESC"
+    );
+    let mut query = sqlx::query_as(&q_str).bind(order_id.as_str());
+    if let Some(alt_id) = alt_id {
+        query = query.bind(alt_id.as_str());
+    }
+    let addresses: Vec<AddressBalance> = query.fetch_all(conn).await?;
     Ok(addresses)
 }
 
@@ -130,7 +134,7 @@ pub(crate) async fn orders_for_address(
     SELECT
         orders.id as id,
         orders.order_id as order_id,
-        orders.alt_d as alt_id,
+        orders.alt_id as alt_id,
         orders.customer_id as customer_id,
         orders.memo as memo,
         orders.total_price as total_price,

--- a/tari_payment_engine/src/sqlite/migrations/0010_alt_order_id.down.sql
+++ b/tari_payment_engine/src/sqlite/migrations/0010_alt_order_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS payments_alt_order_id_idx;
+DROP INDEX IF EXISTS orders_alt_id_idx;

--- a/tari_payment_engine/src/sqlite/migrations/0010_alt_order_id.up.sql
+++ b/tari_payment_engine/src/sqlite/migrations/0010_alt_order_id.up.sql
@@ -1,0 +1,8 @@
+-- The alternative order id is an optional (unique) additional identifier for an order. The order_id is still
+-- considered the primary id, but some queries can also search over the alt_id.
+-- Also see https://sqlite.org/faq.html#q26
+ALTER TABLE orders ADD COLUMN alt_id TEXT;
+ALTER TABLE payments ADD COLUMN alt_order_id TEXT;
+
+CREATE UNIQUE INDEX orders_alt_id_idx ON orders (alt_id);
+CREATE INDEX payments_alt_order_id_idx ON payments (alt_order_id);

--- a/tari_payment_engine/src/sqlite/sqlite_impl.rs
+++ b/tari_payment_engine/src/sqlite/sqlite_impl.rs
@@ -5,7 +5,7 @@ use std::{cmp::Reverse, fmt::Debug};
 
 use chrono::Duration;
 use log::*;
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 use tari_common_types::tari_address::TariAddress;
 use tpg_common::MicroTari;
 
@@ -30,6 +30,7 @@ use crate::{
         TransferStatus,
     },
     order_objects::{ModifyOrderRequest, OrderChanged, OrderQueryFilter},
+    sqlite::db::orders::{fetch_order_by_id_or_alt, fetch_order_by_order_id},
     tpe_api::{
         account_objects::{AddressHistory, CustomerHistory, Pagination},
         exchange_objects::ExchangeRate,
@@ -72,9 +73,14 @@ impl PaymentGatewayDatabase for SqliteDatabase {
         self.url.as_str()
     }
 
-    async fn claim_order(&self, order_id: &OrderId, address: &TariAddress) -> Result<Order, PaymentGatewayError> {
+    async fn claim_order(
+        &self,
+        order_id: &OrderId,
+        address: &TariAddress,
+        strict_mode: bool,
+    ) -> Result<Order, PaymentGatewayError> {
         let mut tx = self.pool.begin().await?;
-        let order = self.claim_order_with_conn(order_id, address, &mut tx).await?;
+        let order = self.claim_order_with_conn(order_id, address, strict_mode, &mut tx).await?;
         tx.commit().await?;
         Ok(order)
     }
@@ -115,7 +121,11 @@ impl PaymentGatewayDatabase for SqliteDatabase {
     /// * Adds the payment amount to the account's total received, and total pending
     ///
     /// Returns the newly created Payment record.
-    async fn process_new_payment(&self, payment: NewPayment) -> Result<Payment, PaymentGatewayError> {
+    async fn process_new_payment(
+        &self,
+        payment: NewPayment,
+        strict_mode: bool,
+    ) -> Result<Payment, PaymentGatewayError> {
         let mut tx = self.pool.begin().await?;
         let maybe_order_id = payment.order_id.clone();
         debug!("🗃️ Payment {} received from [{}]", payment.txid, payment.sender.as_address());
@@ -126,7 +136,7 @@ impl PaymentGatewayDatabase for SqliteDatabase {
                 "🗃️ The payment {} contains an order id ({order_id}), so I'm going to try and claim an existing order",
                 payment.txid
             );
-            match self.claim_order_with_conn(&order_id, payment.sender.as_address(), &mut tx).await {
+            match self.claim_order_with_conn(&order_id, payment.sender.as_address(), strict_mode, &mut tx).await {
                 Ok(_) => info!("🗃️ Address {} linked to order {order_id}", payment.sender.as_address()),
                 Err(PaymentGatewayError::OrderNotFound(id)) => {
                     info!(
@@ -296,7 +306,7 @@ impl PaymentGatewayDatabase for SqliteDatabase {
         );
         // Claim the order for the credit note address
         if order.status == OrderStatusType::Unclaimed {
-            self.claim_order_with_conn(&order.order_id, &address, &mut tx).await?;
+            self.claim_order_with_conn(&order.order_id, &address, true, &mut tx).await?;
         }
         let result = self.pay_orders_for_address_with_conn(&address, &[&order], &mut tx).await?;
         if result.is_none() {
@@ -322,14 +332,13 @@ impl PaymentGatewayDatabase for SqliteDatabase {
     /// * The total orders for the account are updated.
     async fn cancel_or_expire_order(
         &self,
-        order_id: &OrderId,
+        id: &OrderId,
         new_status: OrderStatusType,
         reason: &str,
+        strict_mode: bool,
     ) -> Result<Order, PaymentGatewayError> {
         let mut tx = self.pool.begin().await?;
-        let order = orders::fetch_order_by_order_id(order_id, &mut tx)
-            .await?
-            .ok_or_else(|| AccountApiError::OrderDoesNotExist(order_id.clone()))?;
+        let order = Self::fetch_order_by_id(id, strict_mode, &mut tx).await?;
         if !&[OrderStatusType::New, OrderStatusType::Unclaimed].contains(&order.status) {
             error!("🗃️ Order {} is not in 'New' status. Cannot call cancel_or_expire_order", order.id);
             return Err(PaymentGatewayError::OrderModificationForbidden);
@@ -383,29 +392,28 @@ impl PaymentGatewayDatabase for SqliteDatabase {
     /// - If the order status is already `Paid`, an error is returned.
     async fn modify_customer_id_for_order(
         &self,
-        order_id: &OrderId,
+        id: &OrderId,
         new_cid: &str,
+        strict_mode: bool,
     ) -> Result<OrderMovedResult, PaymentGatewayError> {
         let mut tx = self.pool.begin().await?;
-        let old_order = orders::fetch_order_by_order_id(order_id, &mut tx)
-            .await?
-            .ok_or_else(|| AccountApiError::OrderDoesNotExist(order_id.clone()))?;
+        let old_order = Self::fetch_order_by_id(id, strict_mode, &mut tx).await?;
         // Cannot change customer id on orders that have already been paid
         if matches!(old_order.status, OrderStatusType::Paid) {
             return Err(PaymentGatewayError::OrderModificationForbidden);
         }
         if new_cid == old_order.customer_id {
-            debug!("🗃️ Order {order_id} is being reassigned to the same customer. No action taken.");
+            debug!("🗃️ Order {id} is being reassigned to the same customer. No action taken.");
             tx.rollback().await?;
             return Err(PaymentGatewayError::OrderModificationNoOp);
         }
         let update = ModifyOrderRequest::default().with_new_customer_id(new_cid);
-        let mut new_order = orders::update_order(order_id, update, &mut tx).await?.ok_or_else(|| {
+        let mut new_order = orders::update_order(&old_order.order_id, update, &mut tx).await?.ok_or_else(|| {
             error!(
-                "Order {order_id} does not exist, but we fetched it within this same transaction. This should not \
-                 happen. There's a data race of sorts happening here and should be sorted out."
+                "Order {id} does not exist, but we fetched it within this same transaction. This should not happen. \
+                 There's a data race of sorts happening here and should be sorted out."
             );
-            AccountApiError::OrderDoesNotExist(order_id.clone())
+            AccountApiError::OrderDoesNotExist(id.clone())
         })?;
         // Order is either expired, cancelled or new by now. If expired or cancelled, we don't need to make any
         // adjustments but new orders need to be accounted for.
@@ -422,8 +430,7 @@ impl PaymentGatewayDatabase for SqliteDatabase {
                 Ok(None) => { /* noop */ },
                 Err(PaymentGatewayError::AccountError(AccountApiError::InsufficientFunds)) => {
                     debug!(
-                        "🗃️ There weren't enough funds to pay for order {order_id} from the new customer id {} \
-                         immediately",
+                        "🗃️ There weren't enough funds to pay for order {id} from the new customer id {} immediately",
                         new_cid
                     );
                 },
@@ -461,26 +468,25 @@ impl PaymentGatewayDatabase for SqliteDatabase {
     /// - If the order status was `Expired`, or `Cancelled` or `Paid`.
     async fn modify_total_price_for_order(
         &self,
-        order_id: &OrderId,
+        id: &OrderId,
         new_total_price: MicroTari,
+        strict_mode: bool,
     ) -> Result<OrderChanged, PaymentGatewayError> {
         let mut tx = self.pool.begin().await?;
-        let old_order = orders::fetch_order_by_order_id(order_id, &mut tx)
-            .await?
-            .ok_or_else(|| AccountApiError::OrderDoesNotExist(order_id.clone()))?;
+        let old_order = Self::fetch_order_by_id(id, strict_mode, &mut tx).await?;
         if !matches!(old_order.status, OrderStatusType::New) {
-            info!("🗃️ Order {order_id}'s price cannot be changed since it is already {}", old_order.status);
+            info!("🗃️ Order {id}'s price cannot be changed since it is already {}", old_order.status);
             return Err(PaymentGatewayError::OrderModificationForbidden);
         }
         if old_order.total_price == new_total_price {
-            info!("🗃️ Order {order_id}'s price is already {new_total_price}. No action taken.");
+            info!("🗃️ Order {id}'s price is already {new_total_price}. No action taken.");
             return Err(PaymentGatewayError::OrderModificationNoOp);
         }
         let update = ModifyOrderRequest::default().with_new_total_price(new_total_price);
-        let new_order = orders::update_order(order_id, update, &mut tx).await?.ok_or_else(|| {
+        let new_order = orders::update_order(&old_order.order_id, update, &mut tx).await?.ok_or_else(|| {
             let msg = format!(
-                "Order {order_id} does not exist, but we fetched in within this same transaction. This represents a \
-                 bug and the transaction will be rolled back"
+                "Order {id} does not exist, but we fetched in within this same transaction. This represents a bug and \
+                 the transaction will be rolled back"
             );
             error!("{msg}");
             PaymentGatewayError::DatabaseError(msg)
@@ -518,6 +524,18 @@ impl AccountManagement for SqliteDatabase {
     async fn fetch_order_by_order_id(&self, order_id: &OrderId) -> Result<Option<Order>, AccountApiError> {
         let mut conn = self.pool.acquire().await?;
         let order = orders::fetch_order_by_order_id(order_id, &mut conn).await?;
+        Ok(order)
+    }
+
+    async fn fetch_order_by_alt_id(&self, alt: &OrderId) -> Result<Option<Order>, AccountApiError> {
+        let mut conn = self.pool.acquire().await?;
+        let order = orders::fetch_order_by_alt_id(alt, &mut conn).await?;
+        Ok(order)
+    }
+
+    async fn fetch_order_by_id_or_alt(&self, id: &OrderId) -> Result<Option<Order>, AccountApiError> {
+        let mut conn = self.pool.acquire().await?;
+        let order = orders::fetch_order_by_id_or_alt(id, &mut conn).await?;
         Ok(order)
     }
 
@@ -764,15 +782,23 @@ impl SqliteDatabase {
         Ok(result)
     }
 
+    async fn fetch_order_by_id(
+        id: &OrderId,
+        strict_mode: bool,
+        conn: &mut SqliteConnection,
+    ) -> Result<Order, AccountApiError> {
+        if strict_mode { fetch_order_by_order_id(id, conn).await? } else { fetch_order_by_id_or_alt(id, conn).await? }
+            .ok_or_else(|| AccountApiError::OrderDoesNotExist(id.clone()))
+    }
+
     async fn claim_order_with_conn(
         &self,
-        order_id: &OrderId,
+        id: &OrderId,
         address: &TariAddress,
+        strict_mode: bool,
         tx: &mut sqlx::SqliteConnection,
     ) -> Result<Order, PaymentGatewayError> {
-        let order = orders::fetch_order_by_order_id(order_id, tx)
-            .await?
-            .ok_or_else(|| PaymentGatewayError::OrderNotFound(order_id.clone()))?;
+        let order = Self::fetch_order_by_id(id, strict_mode, tx).await?;
         let addr58 = address.to_base58();
         if order.status != OrderStatusType::Unclaimed {
             warn!(

--- a/tari_payment_engine/src/tpe_api/accounts_api.rs
+++ b/tari_payment_engine/src/tpe_api/accounts_api.rs
@@ -37,6 +37,14 @@ where B: AccountManagement
         self.db.fetch_order_by_order_id(order_id).await
     }
 
+    pub async fn fetch_order_by_alt_id(&self, order_id: &OrderId) -> Result<Option<Order>, AccountApiError> {
+        self.db.fetch_order_by_alt_id(order_id).await
+    }
+
+    pub async fn fetch_order_by_id_or_alt(&self, order_id: &OrderId) -> Result<Option<Order>, AccountApiError> {
+        self.db.fetch_order_by_id_or_alt(order_id).await
+    }
+
     /// Fetches all orders associated with the given Tari address, and wraps them in an `OrderResult`, which includes
     /// the metadata of the address and the sum of the orders' values.
     pub async fn orders_for_address(&self, address: &TariAddress) -> Result<OrderResult, AccountApiError> {

--- a/tari_payment_engine/src/tpe_api/order_objects.rs
+++ b/tari_payment_engine/src/tpe_api/order_objects.rs
@@ -43,6 +43,7 @@ where D: serde::Deserializer<'de> {
 pub struct OrderQueryFilter {
     pub memo: Option<String>,
     pub order_id: Option<OrderId>,
+    pub alt_id: Option<OrderId>,
     pub customer_id: Option<String>,
     pub currency: Option<String>,
     pub since: Option<DateTime<Utc>>,
@@ -79,6 +80,11 @@ impl OrderQueryFilter {
 
     pub fn with_order_id(mut self, order_id: OrderId) -> Self {
         self.order_id = Some(order_id);
+        self
+    }
+
+    pub fn with_alt_id(mut self, alt_id: OrderId) -> Self {
+        self.alt_id = Some(alt_id);
         self
     }
 
@@ -124,6 +130,9 @@ impl Display for OrderQueryFilter {
         }
         if let Some(order_id) = &self.order_id {
             write!(f, "order_id: {order_id}. ")?;
+        }
+        if let Some(alt_id) = &self.alt_id {
+            write!(f, "alt_id: {alt_id}. ")?;
         }
         if let Some(customer_id) = &self.customer_id {
             write!(f, "customer_id: {customer_id}. ")?;

--- a/tari_payment_engine/src/traits/account_management.rs
+++ b/tari_payment_engine/src/traits/account_management.rs
@@ -70,6 +70,13 @@ pub trait AccountManagement {
     async fn fetch_orders_for_address(&self, address: &TariAddress) -> Result<Vec<Order>, AccountApiError>;
 
     async fn fetch_order_by_order_id(&self, order_id: &OrderId) -> Result<Option<Order>, AccountApiError>;
+    async fn fetch_order_by_alt_id(&self, alt: &OrderId) -> Result<Option<Order>, AccountApiError>;
+    async fn fetch_order_by_id_or_alt(&self, id: &OrderId) -> Result<Option<Order>, AccountApiError>;
+
+    async fn fetch_order_by_id(&self, id: &OrderId, strict_mode: bool) -> Result<Order, AccountApiError> {
+        if strict_mode { self.fetch_order_by_order_id(id).await? } else { self.fetch_order_by_id_or_alt(id).await? }
+            .ok_or_else(|| AccountApiError::OrderDoesNotExist(id.clone()))
+    }
 
     async fn fetch_payments_for_address(&self, address: &TariAddress) -> Result<Vec<Payment>, AccountApiError>;
 

--- a/tari_payment_engine/src/traits/payment_gateway_database.rs
+++ b/tari_payment_engine/src/traits/payment_gateway_database.rs
@@ -42,7 +42,11 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
     /// with the customer id in the order. If there are multiple addresses, the most recent one is used.
     ///
     /// The order status must be `Unclaimed`, and will be set to `New` if the claim is successful.
-    async fn auto_claim_order(&self, order: &Order) -> Result<Option<(TariAddress, Order)>, PaymentGatewayError>;
+    async fn auto_claim_order(
+        &self,
+        order: &Order,
+        strict_mode: bool,
+    ) -> Result<Option<(TariAddress, Order)>, PaymentGatewayError>;
 
     /// Takes a new order, and in a single atomic transaction, stores the order in the database.
     /// This call is idempotent
@@ -82,7 +86,11 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
     /// Tries to pay for an order using any addresses associated with the customer id attached to this order.
     /// If you've claimed an order, or otherwise know which address you want to pay from, use
     /// [`try_pay_orders_from_address`] instead.
-    async fn try_pay_order(&self, order: &Order) -> Result<Option<MultiAccountPayment>, PaymentGatewayError>;
+    async fn try_pay_order(
+        &self,
+        order: &Order,
+        strict_mode: bool,
+    ) -> Result<Option<MultiAccountPayment>, PaymentGatewayError>;
 
     /// Tries to fulfil the orders using the address as payment source.
     ///

--- a/tari_payment_engine/src/traits/payment_gateway_database.rs
+++ b/tari_payment_engine/src/traits/payment_gateway_database.rs
@@ -26,12 +26,17 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
     fn url(&self) -> &str;
 
     /// Claim the order, identified by `order_id` for the given wallet `address`.
-    ///
+    /// If `strict_mode` is false, the order can also be matched by `alt_id`.
     /// The order must currently be `Unclaimed`.
     ///
     /// The customer id in the order will be associated with the address as part of the claim.
     /// Returns the updated order record.
-    async fn claim_order(&self, order_id: &OrderId, address: &TariAddress) -> Result<Order, PaymentGatewayError>;
+    async fn claim_order(
+        &self,
+        order_id: &OrderId,
+        address: &TariAddress,
+        strict_mode: bool,
+    ) -> Result<Order, PaymentGatewayError>;
 
     /// Attempt to automatically claim the order, by looking for any addresses that are already associated
     /// with the customer id in the order. If there are multiple addresses, the most recent one is used.
@@ -48,9 +53,12 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
     /// * calls `save_payment` to store the payment in the database. If the payment already exists, nothing further is
     ///   done.
     /// * The payment is marked as `Unconfirmed`
+    /// * If an order id is present in the metadata, we check if existing orders can be claimed by the payment. If
+    ///   `strict_mode` is true, only `order_id`s are check. If false, `alt_ids` are also checked.
     ///
     /// Returns the newly created Payment record.
-    async fn process_new_payment(&self, payment: NewPayment) -> Result<Payment, PaymentGatewayError>;
+    async fn process_new_payment(&self, payment: NewPayment, strict_mode: bool)
+        -> Result<Payment, PaymentGatewayError>;
 
     /// Fetches all pending payments for the given address.
     async fn fetch_pending_payments_for_address(
@@ -123,9 +131,10 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
     /// * An audit log entry is made.
     async fn cancel_or_expire_order(
         &self,
-        order: &OrderId,
+        id: &OrderId,
         new_status: OrderStatusType,
         reason: &str,
+        strict_mode: bool,
     ) -> Result<Order, PaymentGatewayError>;
 
     /// Manually reset an order from `Expired` or `Cancelled` status to `New` status.
@@ -159,8 +168,9 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
     /// - If the order status is already `Paid`, an error is returned.
     async fn modify_customer_id_for_order(
         &self,
-        order_id: &OrderId,
+        id: &OrderId,
         new_customer_id: &str,
+        strict_mode: bool,
     ) -> Result<OrderMovedResult, PaymentGatewayError>;
 
     /// Changes the memo field for an order.
@@ -191,6 +201,7 @@ pub trait PaymentGatewayDatabase: Clone + AccountManagement {
         &self,
         order_id: &OrderId,
         new_total_price: MicroTari,
+        strict_mode: bool,
     ) -> Result<OrderChanged, PaymentGatewayError>;
 
     /// Since only XTR is supported currently, this method will always return an error.

--- a/tari_payment_engine/tests/burst_orders.rs
+++ b/tari_payment_engine/tests/burst_orders.rs
@@ -37,7 +37,7 @@ fn burst_orders() {
             let price = MicroTari::from(1_000_000 * (i + 1) as i64);
             let order_id = OrderId::from(format!("oid-2024/{}-burstorder", i * 100));
             let new_order = NewOrder::new(order_id, cid, price);
-            if let Err(e) = api.process_new_order(new_order, true).await {
+            if let Err(e) = api.process_new_order(new_order, true, true).await {
                 panic!("Error processing order {i}: {e}");
             }
         }

--- a/tari_payment_engine/tests/burst_transfers.rs
+++ b/tari_payment_engine/tests/burst_transfers.rs
@@ -38,7 +38,7 @@ fn burst_transfers() {
             let amount = MicroTari::from((i + 1) as i64 * 1_000_000);
 
             let payment = NewPayment::new(pk.clone(), amount, format!("taritx-00-{i}"));
-            let _res = api.process_new_payment(payment).await.expect("Error processing payment");
+            let _res = api.process_new_payment(payment, true).await.expect("Error processing payment");
         }
     });
 }

--- a/tari_payment_server/src/endpoint_tests/mocks.rs
+++ b/tari_payment_server/src/endpoint_tests/mocks.rs
@@ -11,6 +11,8 @@ mock! {
     pub AccountManager {}
     impl AccountManagement for AccountManager {
         async fn fetch_order_by_order_id(&self, order_id: &OrderId) -> Result<Option<Order>, AccountApiError>;
+        async fn fetch_order_by_alt_id(&self, order_id: &OrderId) -> Result<Option<Order>, AccountApiError>;
+        async fn fetch_order_by_id_or_alt(&self, order_id: &OrderId) -> Result<Option<Order>, AccountApiError>;
         async fn fetch_payments_for_address(&self, address: &TariAddress) -> Result<Vec<Payment>, AccountApiError>;
         async fn history_for_address(&self, address: &TariAddress) -> Result<AddressHistory, AccountApiError>;
         async fn search_orders(&self, query: OrderQueryFilter) -> Result<Vec<Order>, AccountApiError>;

--- a/tari_payment_server/src/endpoint_tests/orders.rs
+++ b/tari_payment_server/src/endpoint_tests/orders.rs
@@ -93,6 +93,7 @@ fn orders_response(_: &TariAddress) -> Result<Vec<Order>, AccountApiError> {
         Order {
             id: 0,
             order_id: OrderId("0000001".into()),
+            alt_id: Some(OrderId("#1001".into())),
             customer_id: "1".to_string(),
             memo: None,
             total_price: MicroTari::from(100),
@@ -105,6 +106,7 @@ fn orders_response(_: &TariAddress) -> Result<Vec<Order>, AccountApiError> {
         Order {
             id: 1,
             order_id: OrderId("0000002".into()),
+            alt_id: Some(OrderId("#1002".into())),
             customer_id: "1".to_string(),
             memo: None,
             total_price: MicroTari::from(150),
@@ -117,4 +119,4 @@ fn orders_response(_: &TariAddress) -> Result<Vec<Order>, AccountApiError> {
     ])
 }
 
-const ORDERS_JSON: &str = r#"{"address":"14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2","total_orders":250,"orders":[{"id":0,"order_id":"0000001","customer_id":"1","memo":null,"total_price":100,"original_price":null,"currency":"XTR","created_at":"2024-02-29T13:30:00Z","updated_at":"2024-02-29T13:30:00Z","status":"Paid"},{"id":1,"order_id":"0000002","customer_id":"1","memo":null,"total_price":150,"original_price":null,"currency":"XTR","created_at":"2024-03-15T18:30:00Z","updated_at":"2024-03-16T11:20:00Z","status":"Cancelled"}]}"#;
+const ORDERS_JSON: &str = r##"{"address":"14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2","total_orders":250,"orders":[{"id":0,"order_id":"0000001","alt_id":"#1001","customer_id":"1","memo":null,"total_price":100,"original_price":null,"currency":"XTR","created_at":"2024-02-29T13:30:00Z","updated_at":"2024-02-29T13:30:00Z","status":"Paid"},{"id":1,"order_id":"0000002","alt_id":"#1002","customer_id":"1","memo":null,"total_price":150,"original_price":null,"currency":"XTR","created_at":"2024-03-15T18:30:00Z","updated_at":"2024-03-16T11:20:00Z","status":"Cancelled"}]}"##;

--- a/tari_payment_server/src/routes.rs
+++ b/tari_payment_server/src/routes.rs
@@ -1,6 +1,6 @@
 //! Request handler definitions
 //!
-//! Define each route and it handler here.
+//! Define each  and it handler here.
 //! Handlers that are more than a line or two MUST go into a separate module. Keep this module neat and tidy 🙏
 //!
 //! A note about performance:
@@ -54,7 +54,7 @@ use tari_payment_engine::{
 
 use crate::{
     auth::{check_login_token_signature, JwtClaims, TokenIssuer},
-    config::ProxyConfig,
+    config::ServerOptions,
     data_objects::{
         ExchangeRateResult,
         JsonResponse,
@@ -433,7 +433,7 @@ pub async fn order_by_id<B: AccountManagement>(
     // OR they have the `ReadAll`/`SuperAdmin` role
     let is_admin = claims.roles.contains(&Role::ReadAll) || claims.roles.contains(&Role::SuperAdmin);
     if is_admin {
-        let order = api.as_ref().fetch_order_by_order_id(&order_id).await.map_err(|e| {
+        let order = api.as_ref().fetch_order_by_id_or_alt(&order_id).await.map_err(|e| {
             debug!("💻️ Could not fetch order. {e}");
             ServerError::BackendError(e.to_string())
         })?;
@@ -458,6 +458,7 @@ route!(claim_order => Post "/order/claim" impl PaymentGatewayDatabase);
 pub async fn claim_order<B: PaymentGatewayDatabase>(
     body: web::Json<MemoSignature>,
     api: web::Data<OrderFlowApi<B>>,
+    config: web::Data<ServerOptions>,
 ) -> Result<HttpResponse, ServerError> {
     let memo_signature = body.into_inner();
     debug!(
@@ -465,7 +466,7 @@ pub async fn claim_order<B: PaymentGatewayDatabase>(
         memo_signature.address.as_address(),
         memo_signature.order_id
     );
-    let result = api.claim_order(&memo_signature).await.map_err(|e| {
+    let result = api.claim_order(&memo_signature, config.strict_mode).await.map_err(|e| {
         debug!("💻️ Order claim failed. {e}");
         e
     })?;
@@ -521,6 +522,7 @@ pub async fn addresses<B: AccountManagement>(
 }
 
 route!(settle_address => Post "/settle/address/{address}" impl PaymentGatewayDatabase where requires [Role::Write]);
+/// Forces a check for whether any orders for `address` are able to be paid.
 pub async fn settle_address<B: PaymentGatewayDatabase>(
     path: web::Path<SerializedTariAddress>,
     api: web::Data<OrderFlowApi<B>>,
@@ -535,6 +537,7 @@ pub async fn settle_address<B: PaymentGatewayDatabase>(
 }
 
 route!(settle_customer => Post "/settle/customer/{customer_id}" impl PaymentGatewayDatabase where requires [Role::Write]);
+/// Forces a check for whether any orders for `customer_id` are able to be paid.
 pub async fn settle_customer<B: PaymentGatewayDatabase>(
     path: web::Path<String>,
     api: web::Data<OrderFlowApi<B>>,
@@ -549,6 +552,7 @@ pub async fn settle_customer<B: PaymentGatewayDatabase>(
 }
 
 route!(settle_my_account => Post "/settle" impl PaymentGatewayDatabase);
+/// Forces a check for whether any orders for the authenticated user are able to be paid.
 pub async fn settle_my_account<B: PaymentGatewayDatabase>(
     claims: JwtClaims,
     api: web::Data<OrderFlowApi<B>>,
@@ -651,10 +655,11 @@ route!(fulfil_order => Post "/fulfill" impl PaymentGatewayDatabase where require
 pub async fn fulfil_order<B: PaymentGatewayDatabase>(
     body: web::Json<ModifyOrderParams>,
     api: web::Data<OrderFlowApi<B>>,
+    config: web::Data<ServerOptions>,
 ) -> Result<HttpResponse, ServerError> {
     let ModifyOrderParams { order_id, reason } = body.into_inner();
     debug!("💻️ Fulfilment request for {order_id} with reason: {reason}");
-    let order = api.mark_new_order_as_paid(&order_id, &reason).await.map_err(|e| {
+    let order = api.mark_new_order_as_paid(&order_id, &reason, config.strict_mode).await.map_err(|e| {
         debug!("💻️ Could not fulfil order. {e}");
         e
     })?;
@@ -677,13 +682,17 @@ route!(cancel_order => Post "/cancel" impl PaymentGatewayDatabase where requires
 pub async fn cancel_order<B: PaymentGatewayDatabase>(
     body: web::Json<ModifyOrderParams>,
     api: web::Data<OrderFlowApi<B>>,
+    config: web::Data<ServerOptions>,
 ) -> Result<HttpResponse, ServerError> {
     let ModifyOrderParams { order_id, reason } = body.into_inner();
     info!("💻️ Cancel order request for {order_id}. Reason: {reason}");
-    let order = api.cancel_or_expire_order(&order_id, OrderStatusType::Cancelled, &reason).await.map_err(|e| {
-        debug!("💻️ Could not cancel order. {e}");
-        e
-    })?;
+    let order = api
+        .cancel_or_expire_order(&order_id, OrderStatusType::Cancelled, &reason, config.strict_mode)
+        .await
+        .map_err(|e| {
+            debug!("💻️ Could not cancel order. {e}");
+            e
+        })?;
     Ok(HttpResponse::Ok().json(order))
 }
 
@@ -711,11 +720,12 @@ route!(update_order_memo => Patch "/order_memo" impl PaymentGatewayDatabase wher
 pub async fn update_order_memo<B: PaymentGatewayDatabase>(
     body: web::Json<UpdateMemoParams>,
     api: web::Data<OrderFlowApi<B>>,
+    config: web::Data<ServerOptions>,
 ) -> Result<HttpResponse, ServerError> {
     let UpdateMemoParams { order_id, new_memo, reason } = body.into_inner();
     let reason = reason.unwrap_or_else(|| "No reason provided".to_string());
     info!("💻️ Update order memos request for {order_id}. Reason: {reason}");
-    let order = api.update_memo_for_order(&order_id, &new_memo).await.map_err(|e| {
+    let order = api.update_memo_for_order(&order_id, &new_memo, config.strict_mode).await.map_err(|e| {
         debug!("💻️ Could not update order memo. {e}");
         e
     })?;
@@ -736,11 +746,12 @@ route!(update_price => Patch "/order_price" impl PaymentGatewayDatabase where re
 pub async fn update_price<B: PaymentGatewayDatabase>(
     body: web::Json<UpdatePriceParams>,
     api: web::Data<OrderFlowApi<B>>,
+    config: web::Data<ServerOptions>,
 ) -> Result<HttpResponse, ServerError> {
     let UpdatePriceParams { order_id, new_price, reason } = body.into_inner();
     let reason = reason.unwrap_or_else(|| "No reason provided".to_string());
     info!("💻️ Update order price request for {order_id}. Reason: {reason}");
-    let order = api.update_price_for_order(&order_id, new_price).await.map_err(|e| {
+    let order = api.update_price_for_order(&order_id, new_price, config.strict_mode).await.map_err(|e| {
         debug!("💻️ Could not update order price. {e}");
         e
     })?;
@@ -748,7 +759,7 @@ pub async fn update_price<B: PaymentGatewayDatabase>(
 }
 
 route!(reassign_order => Patch "/reassign_order" impl PaymentGatewayDatabase where requires [Role::Write]);
-/// Provides an endpoint for admins to adjust the price of an order.
+/// Provides an endpoint for admins to reassign an order to a different customer id.
 /// Admins can call `PATCH /api/reassign_order` with the order_id, new customer_id, and a reason to reassign an order
 /// to a different customer.
 ///
@@ -758,21 +769,23 @@ route!(reassign_order => Patch "/reassign_order" impl PaymentGatewayDatabase whe
 /// ```json
 /// {
 ///     "orders": { "new_order": {}, "old_order": {} },
-///     "old_account_id": 1000,
-///     "new_account_id": 1200,
-///     "is_filled": false
+///     "settlements": [
+///       { "order_id": "12345", "amount": 240, "status": "Settled", ... }
+///     ]
 ///  }
 /// ```
 pub async fn reassign_order<B: PaymentGatewayDatabase>(
     body: web::Json<MoveOrderParams>,
     api: web::Data<OrderFlowApi<B>>,
+    config: web::Data<ServerOptions>,
 ) -> Result<HttpResponse, ServerError> {
     let MoveOrderParams { order_id, new_customer_id, reason } = body.into_inner();
     info!("💻️ Assigning existing order {order_id} to customer {new_customer_id}. Reason: {reason}");
-    let order = api.assign_order_to_new_customer(&order_id, &new_customer_id).await.map_err(|e| {
-        debug!("💻️ Could not assign order. {e}");
-        e
-    })?;
+    let order =
+        api.assign_order_to_new_customer(&order_id, &new_customer_id, config.strict_mode).await.map_err(|e| {
+            debug!("💻️ Could not assign order. {e}");
+            e
+        })?;
     Ok(HttpResponse::Ok().json(order))
 }
 
@@ -813,7 +826,7 @@ pub async fn reset_order<B: PaymentGatewayDatabase>() -> Result<HttpResponse, Se
 route!(incoming_payment_notification => Post "/incoming_payment" impl PaymentGatewayDatabase, WalletAuth );
 pub async fn incoming_payment_notification<BOrder, BAuth>(
     req: HttpRequest,
-    config: web::Data<ProxyConfig>,
+    config: web::Data<ServerOptions>,
     auth_api: web::Data<WalletAuthApi<BAuth>>,
     order_api: web::Data<OrderFlowApi<BOrder>>,
     body: web::Json<PaymentNotification>,
@@ -828,6 +841,7 @@ where
     let use_forwarded = config.use_forwarded;
     let disable_whitelist = config.disable_wallet_whitelist;
     let require_memo_signature = !config.disable_memo_signature_check;
+    let strict_mode = config.strict_mode;
     // Log the payment
     trace!("💻️ Extracting remote IP address. {req:?}. {:?}", req.connection_info());
     let peer_addr = match (get_remote_ip(&req, use_x_forwarded_for, use_forwarded), disable_whitelist) {
@@ -869,7 +883,7 @@ where
         Some(false) => debug!("💻️ Payment memo does not contain a valid claim for an order."),
         None => debug!("💻️ Payment memo was empty and did thus did not contain a claim for an order"),
     }
-    let result = match order_api.process_new_payment(payment).await {
+    let result = match order_api.process_new_payment(payment, strict_mode).await {
         Ok(payment) => {
             info!("💻️ Incoming payment processed successfully for {}.", payment.sender);
             let body = serde_json::to_string(&payment).unwrap_or_else(|e| format!("{e}"));
@@ -894,7 +908,7 @@ where
 route!(tx_confirmation_notification => Post "/tx_confirmation" impl PaymentGatewayDatabase, WalletAuth );
 pub async fn tx_confirmation_notification<BOrder, BAuth>(
     req: HttpRequest,
-    config: web::Data<ProxyConfig>,
+    config: web::Data<ServerOptions>,
     auth_api: web::Data<WalletAuthApi<BAuth>>,
     order_api: web::Data<OrderFlowApi<BOrder>>,
     body: web::Json<TransactionConfirmationNotification>,
@@ -936,7 +950,10 @@ where
     }
     let auth_api = auth_api.as_ref();
     if let Err(e) = auth_api.authenticate_wallet(auth, peer_addr.as_ref(), &confirmation, disable_whitelist).await {
-        warn!("💻️ Unauthorized wallet signature received from {peer_addr:?}. Reason: {e}. The request is rejected.");
+        warn!(
+            "💻️ Unauthorized wallet signature received from {peer_addr:?} for payment confirmation. Reason: {e}. The \
+             request is rejected."
+        );
         return HttpResponse::Unauthorized().finish();
     }
     // -- from here on, we trust that the notification is legitimate.

--- a/tari_payment_server/src/server.rs
+++ b/tari_payment_server/src/server.rs
@@ -24,7 +24,7 @@ use tari_payment_engine::{
 
 use crate::{
     auth::{build_tps_authority, TokenIssuer},
-    config::{ProxyConfig, ServerConfig},
+    config::{ServerConfig, ServerOptions},
     errors::{AuthError, ServerError, ServerError::AuthenticationError},
     expiry_worker::start_expiry_worker,
     helpers::get_remote_ip,
@@ -113,7 +113,7 @@ pub fn create_server_instance(
     db: SqliteDatabase,
     producers: EventProducers,
 ) -> Result<Server, ServerError> {
-    let proxy_config = ProxyConfig::from_config(&config);
+    let proxy_config = ServerOptions::from_config(&config);
     let shopify_config = config.shopify_config.shopify_api_config();
     let order_id_field = config.shopify_config.order_id_field;
     let shopify_api = ShopifyApi::new(shopify_config).map_err(|e| {

--- a/tari_payment_server/src/shopify_routes.rs
+++ b/tari_payment_server/src/shopify_routes.rs
@@ -19,7 +19,6 @@ use tari_payment_engine::{
 use tpg_common::MicroTari;
 
 use crate::{
-    config::OrderIdField,
     data_objects::{ExchangeRateUpdate, JsonResponse},
     errors::ServerError,
     integrations::shopify::{new_order_from_shopify_order, OrderConversionError},
@@ -32,7 +31,6 @@ pub async fn shopify_webhook<BPay, BFx>(
     body: web::Json<ShopifyOrder>,
     api: web::Data<OrderFlowApi<BPay>>,
     fx: web::Data<ExchangeRateApi<BFx>>,
-    order_id_field: web::Data<OrderIdField>,
 ) -> HttpResponse
 where
     BPay: PaymentGatewayDatabase,
@@ -41,8 +39,7 @@ where
     trace!("🛍️️ Received webhook request: {}", req.uri());
     let order = body.into_inner();
     // Webhook responses must always be in 200 range, otherwise Shopify will retry
-    let id_field = *order_id_field.into_inner();
-    let result = match new_order_from_shopify_order(order, &fx, id_field).await {
+    let result = match new_order_from_shopify_order(order, &fx).await {
         Err(OrderConversionError::FormatError(s)) => {
             warn!("🛍️️ Could not convert order. {s}");
             JsonResponse::failure(s)

--- a/tari_payment_server/src/shopify_routes.rs
+++ b/tari_payment_server/src/shopify_routes.rs
@@ -19,6 +19,7 @@ use tari_payment_engine::{
 use tpg_common::MicroTari;
 
 use crate::{
+    config::ServerOptions,
     data_objects::{ExchangeRateUpdate, JsonResponse},
     errors::ServerError,
     integrations::shopify::{new_order_from_shopify_order, OrderConversionError},
@@ -31,6 +32,7 @@ pub async fn shopify_webhook<BPay, BFx>(
     body: web::Json<ShopifyOrder>,
     api: web::Data<OrderFlowApi<BPay>>,
     fx: web::Data<ExchangeRateApi<BFx>>,
+    config: web::Data<ServerOptions>,
 ) -> HttpResponse
 where
     BPay: PaymentGatewayDatabase,
@@ -52,7 +54,7 @@ where
             info!("🛍️️ Unsupported currency in incoming order. {cur}");
             JsonResponse::failure(format!("Unsupported currency: {cur}"))
         },
-        Ok(new_order) => match api.process_new_order(new_order.clone(), true).await {
+        Ok(new_order) => match api.process_new_order(new_order.clone(), true, config.strict_mode).await {
             Ok(order) => {
                 info!(
                     "🛍️️ Order {} for {} processed successfully. Current status is {}",


### PR DESCRIPTION


Add **strict mode** for order ID matching and update related methods

This PR introduces a new strict mode for order ID matching, which ensures that only the primary order ID is used for identifying orders when enabled (this was the default behavior prior to this PR).

When strict mode is disabled, both the primary order ID and an alternative ID can be used. This change affects various parts of the codebase, including configuration, database queries, and API endpoints.

1. **Configuration Updates:**
   - Added `TPG_STRICT_MODE` environment variable to `.env.sample`.
   - Updated `ServerConfig` and `ServerOptions` structs to include `strict_mode` field.
   - Modified `ServerConfig::from_env` to read `TPG_STRICT_MODE` and set `strict_mode` accordingly.

2. **Database Schema and Trait Updates:**
   - Added `alt_id` field to `Order` struct in `order_objects.rs`.
   - Updated `AccountManagement` and `PaymentGatewayDatabase` traits to include methods for fetching orders by alternative ID and handling strict mode.

3. **Method Updates:**
   - Updated various methods in `PaymentGatewayDatabase` to accept `strict_mode` parameter and adjust order fetching logic accordingly.
   - Modified methods in `AccountManagement` to handle strict mode and fetch orders by either primary or alternative ID.
   - `fetch_orders_for_address` will also return "Unclaimed" orders in
     addition to "new" orders if they're associated with an address
     already. This feels more in line with expected behaviour.

4. **API Endpoint Updates:**
   - Updated API endpoints in `routes.rs` to pass `strict_mode` from `ServerOptions` to the relevant methods.
   - Adjusted endpoint handlers to use the new strict mode logic for order processing, payment confirmation, and order updates.

5. **Test Updates:**
   - Modified tests in `burst_transfers.rs` and `endpoint_tests` to include `strict_mode` parameter.
   - Updated mock implementations to support fetching orders by alternative ID.

6. **Shopify Integration Updates:**
   - Removed `OrderIdField` and updated `new_order_from_shopify_order` to set both primary and alternative order IDs.
   - Adjusted Shopify webhook handler to use the new strict mode logic.

- Fixed incorrect handling of environment variables in `ServerConfig::from_env`.

- Improved logging messages to include alternative order IDs where applicable.