### PR TITLE
feat: rescan open orders

### DIFF
--- a/tari_payment_server/src/server.rs
+++ b/tari_payment_server/src/server.rs
@@ -61,6 +61,7 @@ use crate::{
         PaymentsRoute,
         ReassignOrderRoute,
         RemoveAuthorizedWalletRoute,
+        RescanOpenOrdersRoute,
         ResetOrderRoute,
         SettleAddressRoute,
         SettleCustomerRoute,
@@ -183,6 +184,7 @@ pub fn create_server_instance(
             .service(SettleAddressRoute::<SqliteDatabase>::new())
             .service(SettleCustomerRoute::<SqliteDatabase>::new())
             .service(SettleMyAccountRoute::<SqliteDatabase>::new())
+            .service(RescanOpenOrdersRoute::<SqliteDatabase, SqliteDatabase>::new())
             .service(CheckTokenRoute::new());
         let use_x_forwarded_for = config.use_x_forwarded_for;
         let use_forwarded = config.use_forwarded;

--- a/taritools/src/interactive/menus.rs
+++ b/taritools/src/interactive/menus.rs
@@ -37,6 +37,7 @@ pub mod commands {
     pub const PAYMENTS_FOR_ADDRESS: &str = "Payments for Address";
     pub const REASSIGN_ORDER: &str = "Reassign Order";
     pub const REMOVE_AUTH_WALLETS: &str = "Remove authorized wallets";
+    pub const RESCAN_OPEN_ORDERS: &str = "Re-import Open Orders";
     pub const RESET_ORDER: &str = "Reset Order";
     pub const SERVER_HEALTH: &str = "Server health";
     pub const SHOPIFY_OPEN_ORDERS: &str = "Open Orders";
@@ -47,7 +48,7 @@ pub use commands::*;
 
 pub const TOP_MENU: [&str; 5] = [NAV_TO_ADMIN_MENU, NAV_TO_USER_MENU, NAV_TO_SHOPIFY_MENU, LOGOUT, EXIT];
 
-pub const ADMIN_MENU: [&str; 23] = [
+pub const ADMIN_MENU: [&str; 24] = [
     CANCEL,
     MARK_ORDER_PAID,
     RESET_ORDER,
@@ -66,6 +67,7 @@ pub const ADMIN_MENU: [&str; 23] = [
     HISTORY_FOR_ACCOUNT_ID,
     EDIT_MEMO,
     REASSIGN_ORDER,
+    RESCAN_OPEN_ORDERS,
     ADD_AUTH_WALLET,
     REMOVE_AUTH_WALLETS,
     LIST_AUTH_WALLETS,
@@ -87,7 +89,7 @@ pub const USER_MENU: [&str; 11] = [
     LIST_PAYMENT_ADDRESSES,
 ];
 
-pub const SHOPIFY_MENU: [&str; 3] = [SHOPIFY_OPEN_ORDERS, NAV_BACK, EXIT];
+pub const SHOPIFY_MENU: [&str; 4] = [SHOPIFY_OPEN_ORDERS, NAV_BACK, RESCAN_OPEN_ORDERS, EXIT];
 
 pub fn top_menu() -> &'static Menu {
     &("Main", &TOP_MENU)

--- a/taritools/src/interactive/mod.rs
+++ b/taritools/src/interactive/mod.rs
@@ -165,6 +165,7 @@ impl InteractiveApp {
                 LIST_AUTH_WALLETS => handle_response(self.list_authorized_wallets().await),
                 ADD_PROFILE => handle_response(self.add_profile().await),
                 SHOPIFY_OPEN_ORDERS => handle_response(self.shopify_open_orders().await),
+                RESCAN_OPEN_ORDERS => handle_response(self.rescan_open_orders().await),
                 LOGOUT => self.logout(),
                 NAV_BACK => self.pop_menu(),
                 EXIT => break,
@@ -412,6 +413,15 @@ impl InteractiveApp {
         let address = self.select_address().await?;
         let client = self.client().expect("User is logged in. Client should not be None");
         client.orders_for_address(address).await.and_then(format_order_result)
+    }
+
+    async fn rescan_open_orders(&mut self) -> Result<String> {
+        let _unused = self.login().await?;
+        let client = self.client().expect("User is logged in. Client should not be None");
+        let result = client.rescan_open_orders().await?;
+        let result =
+            result.into_iter().map(|r| format!("{}: {}", r.success, r.message)).collect::<Vec<String>>().join("\n");
+        Ok(result)
     }
 
     async fn payments_for_order(&mut self) -> Result<String> {


### PR DESCRIPTION
Add rescan open orders functionality and update related methods

This commit introduces a new feature to rescan open orders from Shopify and update the related methods and routes. The changes include new API endpoint & updated interactive menu commands.

1. **Routes and Handlers:**
   - Added `rescan_open_orders` route in `routes.rs` to handle rescanning open orders.
   - Implemented `rescan_open_orders` handler in `routes.rs` to fetch and process open orders from Shopify.
   - Updated `create_server_instance` in `server.rs` to register the new `RescanOpenOrdersRoute`.

2. **Shopify Integration:**
   - Added `handle_shopify_order` method in `shopify_routes.rs` to process individual Shopify orders.
   - Updated `shopify_routes.rs` to use `handle_shopify_order` for better modularity and reusability.

3. **Interactive Menu Updates:**
   - Added `RESCAN_OPEN_ORDERS` command in `menus.rs` and updated `ADMIN_MENU` and `SHOPIFY_MENU` to include the new command.
   - Implemented `rescan_open_orders` method in `interactive/mod.rs` to handle the new command and interact with the server.

4. **Client Updates:**
   - Added `rescan_open_orders` method in `client.rs` to send a request to the new API endpoint and handle the response.

5. **Logging Enhancements:**
   - Added detailed logging in `rescan_open_orders` handler to trace the process of fetching and adding open orders to the database.