### PR TITLE
feat: payment replay script

### DIFF
--- a/taritools/scripts/tps_notify.sh
+++ b/taritools/scripts/tps_notify.sh
@@ -8,16 +8,24 @@ BINPATH=${TARITOOLS_PATH:-$HOME/.cargo/bin}
 BIN=$BINPATH/taritools
 PROFILE="TPS Hot Wallet"
 LOGFILE=$HOME/.taritools/tps_notify.log
+REPLAYFILE=$HOME/.taritools/tps_notify_replay.log
 
 register_received_payment() {
+  # Log the command we're about to invoke for replays
+  echo "# Payment received $(date)" >>$REPLAYFILE
+  echo ${BIN} wallet received --profile \"$PROFILE\" --amount \"$2\" --txid $3 --memo \"$4\" --sender $6 --payment_id \"$5\" &>>$REPLAYFILE
   ${BIN} wallet received --profile "$PROFILE" --amount "$2" --txid $3 --memo "$4" --sender $6 --payment_id "$5" &>>$LOGFILE
   echo "Registering payment received is complete" >> $LOGFILE
 }
 
 register_confirmation() {
   echo "Signalling payment (possibly again)"
+  echo "# Payment received $(date)" >>$REPLAYFILE
+  echo ${BIN} wallet received --profile \"$PROFILE\" --amount \"$2\" --txid $3 --memo \"$4\" --sender $6 --payment_id \"$5\" &>>$REPLAYFILE
   ${BIN} wallet received --profile "$PROFILE" --amount "$2" --txid $3 --memo "$4" --sender $6 --payment_id "$5" &>>$LOGFILE
   sleep 2
+  echo "# Confirmation received $(date)" >>$REPLAYFILE
+  echo ${BIN} wallet confirmed --profile \"$PROFILE\" --txid $3 &>>$REPLAYFILE
   ${BIN} wallet confirmed --profile "$PROFILE" --txid $3 &>>$LOGFILE
   echo "Registering confirmation received is complete" >> $LOGFILE
 }

--- a/taritools/src/shopify/config.rs
+++ b/taritools/src/shopify/config.rs
@@ -4,7 +4,7 @@ use tari_payment_server::config::OrderIdField;
 
 /// Examines the environment configuration to determine the field used to determine the order id.
 pub fn order_id_field_from_env() -> OrderIdField {
-    env::var("TPG_ORDER_ID_FIELD")
+    env::var("TPG_SHOPIFY_ORDER_ID_FIELD")
         .map(|s| if s.to_lowercase().as_str() == "name" { OrderIdField::Name } else { OrderIdField::Id })
         .unwrap_or_default()
 }


### PR DESCRIPTION
Creates a file with the exact parameters used to call taritools for payments, which can be used to replay payment commands.

Also fixes a bug where the wrong ENVAR was being used by taritools to check the shopify order id field.