### PR TITLE
feat: price field

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,6 +13,7 @@ TPG_SHOPIFY_ADMIN_ACCESS_TOKEN=shpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TPG_SHOPIFY_STOREFRONT_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TPG_STRICT_MODE=1
 TPG_SHOPIFY_ORDER_ID_FIELD=id
+TPG_SHOPIFY_PRICE_FIELD=total
 
 RUST_LOG="error,shopify_payment_gateway=trace"
 # Only used in taritools

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "e2e"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3680,7 +3680,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shopify_tools"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "graphql-parser",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "tari_payment_engine"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "blake2",
  "chrono",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "tari_payment_server"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "actix-http",
  "actix-jwt-auth-middleware",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "taritools"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4775,7 +4775,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tpg_common"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "serde",
  "sqlx",

--- a/e2e/tests/features/order_payment_matching_with_other_prices.feature
+++ b/e2e/tests/features/order_payment_matching_with_other_prices.feature
@@ -1,0 +1,108 @@
+@other_prices
+Feature: Order Fulfillment using different price fields
+  Background:
+    Given a server configuration
+      | use_x_forwarded_for          | true  |
+      | disable_memo_signature_check | true  |
+      | strict_mode                  | false |
+      | price_field                  | subtotal |
+    Given a blank slate
+    Given an authorized wallet with secret df158b8389c68aac01a91276b742d2527f951d3c7289e4ccdecfa0672947270e
+    """
+      {
+        "address": "14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "ip_address": "192.168.1.100"
+      }
+    """
+    Given the exchange rate is 10 Tari per USD
+
+  Scenario: When price field is line_items, paying the subtotal amount is sufficient
+    When Customer #1 ["alice"] places order "1000" with price details:
+     | total      | 300 | USD |
+     | subtotal   | 240 | USD |
+     | line_items | 230 | USD |
+    Then customer id 1 has current orders worth 2400 XTR
+    And account for customer 1 has a current balance of 0 XTR
+    And order "1000" is in state Unclaimed
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {
+      "payment": {
+         "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+         "amount":2500000000,
+         "txid":"payment001",
+         "memo": "order 1000"
+      },
+      "auth": {"address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":1,"signature":"ac509cfdb1915e572faf9fb5c29ee5ab364f177f352f36a8f8b50ab48f34374961103694fea123f30a1e0ec66321186b6c3ead8e5cedf88c64e3256c1610fb03"}
+    }
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    # Transaction is not confirmed yet
+    Then order "1000" is in state New
+    And account for customer 1 has a current balance of 0 XTR
+    And User Alice has a pending balance of 2500 XTR
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "confirmation": {"txid": "payment001"},
+      "auth": {
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "nonce":2,
+        "signature":"16729e3c9b08022a16edfa0bf2e1cfc1d8dadd5e6387b4fd76005ac8a20c0f53087434524748981e9c61f9b7ce122fdf1a45299b132cd4495b19b7d1208cea01"
+      }
+    }
+    """
+    Then order "1000" is in state Paid
+    And account for customer 1 has a current balance of 100 XTR
+    And the OrderPaid trigger fires with
+    """
+    {
+      "order": {
+      "order_id": "1000",
+      "alt_id": "#1000",
+      "customer_id": "1",
+      "total_price": 2400000000,
+      "currency": "USD",
+      "id": 1,
+      "status": "Paid"
+    }
+   }
+   """
+
+  Scenario: When price field is subtotal, paying the line item amount is not sufficient
+    When Customer #1 ["alice"] places order "1000" with price details:
+      | total      | 300 | USD |
+      | subtotal   | 260 | USD |
+      | line_items | 240 | USD |
+    Then customer id 1 has current orders worth 2600 XTR
+    And account for customer 1 has a current balance of 0 XTR
+    And order "1000" is in state Unclaimed
+    When a payment arrives from x-forwarded-for 192.168.1.100
+    """
+    {
+      "payment": {
+         "sender":"14wqR3rjyVbjgXDyLVaL97p3CksHc84cz9hLLMMTMYDjtBt",
+         "amount":2500000000,
+         "txid":"payment001",
+         "memo": "order 1000"
+      },
+      "auth": {"address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG","nonce":1,"signature":"ac509cfdb1915e572faf9fb5c29ee5ab364f177f352f36a8f8b50ab48f34374961103694fea123f30a1e0ec66321186b6c3ead8e5cedf88c64e3256c1610fb03"}
+    }
+    """
+    Then I receive a 200 Ok response with the message '"success":true'
+    # Transaction is not confirmed yet
+    Then order "1000" is in state New
+    And account for customer 1 has a current balance of 0 XTR
+    And User Alice has a pending balance of 2500 XTR
+    When a confirmation arrives from x-forwarded-for 192.168.1.100
+    """
+    { "confirmation": {"txid": "payment001"},
+      "auth": {
+        "address":"14z3iHvgokZcXmokAYQKveeJ4rMqSGtPahrC2CPvx63UQmG",
+        "nonce":2,
+        "signature":"16729e3c9b08022a16edfa0bf2e1cfc1d8dadd5e6387b4fd76005ac8a20c0f53087434524748981e9c61f9b7ce122fdf1a45299b132cd4495b19b7d1208cea01"
+      }
+    }
+    """
+    Then order "1000" is in state New
+    And account for customer 1 has a current balance of 2500 XTR
+

--- a/tari_payment_server/src/shopify_routes.rs
+++ b/tari_payment_server/src/shopify_routes.rs
@@ -55,7 +55,7 @@ where
     BPay: PaymentGatewayDatabase,
     BFx: ExchangeRates,
 {
-    match new_order_from_shopify_order(order, fx).await {
+    match new_order_from_shopify_order(order, config.shopify_price_field, fx).await {
         Err(OrderConversionError::FormatError(s)) => {
             warn!("🛍️️ Could not convert order. {s}");
             JsonResponse::failure(s)


### PR DESCRIPTION
Add a configuration option to inform the server which shopify price field to interpret for order prices.

The default is `total_price`, but you can also choose `line_item_total` or `subtotal`.

The new config variable is 
`TPG_SHOPIFY_PRICE_FIELD={line | subtotal | total }`

A new test was added that tests this new feature (as well as the exchange rate)