### PR TITLE
feat: exclude health endpoint from logs

### DIFF
--- a/tari_payment_server/src/server.rs
+++ b/tari_payment_server/src/server.rs
@@ -139,7 +139,7 @@ pub fn create_server_instance(
         );
 
         let mut app = App::new()
-            .wrap(Logger::new(LOG_FORMAT).log_target("access_log"))
+            .wrap(Logger::new(LOG_FORMAT).log_target("access_log").exclude("/health"))
             .app_data(web::Data::new(orders_api))
             .app_data(web::Data::new(accounts_api))
             .app_data(web::Data::new(shopify_api.clone()))


### PR DESCRIPTION
The `health` endpoint tends to get spammed, so remove it from the access logs.