### PR TITLE
Config pool size

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,6 +14,7 @@ TPG_SHOPIFY_STOREFRONT_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TPG_STRICT_MODE=1
 TPG_SHOPIFY_ORDER_ID_FIELD=id
 TPG_SHOPIFY_PRICE_FIELD=total
+TPG_MAX_CONNECTIONS=25
 
 RUST_LOG="error,shopify_payment_gateway=trace"
 # Only used in taritools

--- a/e2e/tests/cucumber/world.rs
+++ b/e2e/tests/cucumber/world.rs
@@ -57,6 +57,7 @@ impl Default for TPGWorld {
             unpaid_order_timeout: Duration::seconds(4),
             shopify_config: Default::default(),
             strict_mode: true,
+            max_connections: 1,
         };
         Self {
             config,

--- a/tari_payment_engine/tests/burst_orders.rs
+++ b/tari_payment_engine/tests/burst_orders.rs
@@ -1,5 +1,12 @@
-use std::time::Duration;
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
+use futures_util::future::join_all;
 use log::*;
 use tari_payment_engine::{
     db_types::*,
@@ -8,39 +15,58 @@ use tari_payment_engine::{
     OrderFlowApi,
     SqliteDatabase,
 };
-use tokio::runtime::Runtime;
+use tokio::runtime::{Builder, Runtime};
 use tpg_common::MicroTari;
 
-const NUM_ORDERS: u64 = 20;
+const NUM_BATCHES: usize = 20;
+const NUM_THREADS: usize = 5;
 const RATE: u64 = 100; // orders per second
 
 #[test]
 fn burst_orders() {
     info!("🚀️ Starting order injection test");
 
-    let sys = Runtime::new().unwrap();
+    let sys = Builder::new_multi_thread().worker_threads(NUM_THREADS).enable_time().build().unwrap();
 
-    let delay = Duration::from_millis(1000 / RATE);
+    let delay = Duration::from_millis(1000 / RATE * 5);
 
+    let successes = Arc::new(AtomicU64::new(0));
+    let s2 = successes.clone();
+    let num_orders = NUM_BATCHES * NUM_THREADS;
     sys.block_on(async move {
         let url = "sqlite://../data/test_burst_orders.db";
         prepare_test_env(url).await;
-        let db = SqliteDatabase::new_with_url(url, 5).await.expect("Error creating database");
-        let api = OrderFlowApi::new(db, EventProducers::default());
+        let db = SqliteDatabase::new_with_url(url, NUM_THREADS as u32).await.expect("Error creating database");
 
-        let mut timer = tokio::time::interval(delay);
-        info!("🚀️ Injecting {NUM_ORDERS} orders");
-        for i in 0..NUM_ORDERS {
-            timer.tick().await;
-            let cid = ((i + 1) % 5).to_string();
-            #[allow(clippy::cast_possible_wrap)]
-            let price = MicroTari::from(1_000_000 * (i + 1) as i64);
-            let order_id = OrderId::from(format!("oid-2024/{}-burstorder", i * 100));
-            let new_order = NewOrder::new(order_id, cid, price);
-            if let Err(e) = api.process_new_order(new_order, true, true).await {
-                panic!("Error processing order {i}: {e}");
-            }
+        info!("🚀️ Injecting {num_orders} orders");
+        let mut tasks = Vec::with_capacity(NUM_BATCHES);
+        for t in 0..NUM_THREADS {
+            let db2 = db.clone();
+            let s3 = s2.clone();
+            let task = tokio::spawn(async move {
+                let api = OrderFlowApi::new(db2, EventProducers::default());
+
+                for i in 0..NUM_BATCHES {
+                    let mut timer = tokio::time::interval(delay);
+                    timer.tick().await;
+                    let cid = ((i + 1) % 5).to_string();
+                    #[allow(clippy::cast_possible_wrap)]
+                    let price = MicroTari::from(1_000_000 * (i + 1) as i64);
+                    let order_id = OrderId::from(format!("oid-2024/{}.{}-burstorder", t, i * 100));
+                    let new_order = NewOrder::new(order_id, cid, price);
+                    if let Err(e) = api.process_new_order(new_order, true, true).await {
+                        panic!("Error processing order {i}: {e}");
+                    } else {
+                        s3.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            });
+            tasks.push(task);
         }
+        let results = join_all(tasks).await;
+        assert!(results.iter().all(|r| r.is_ok()), "Not all threads completed happily");
     });
+    let successes = successes.as_ref().load(Ordering::SeqCst);
+    assert_eq!(successes, num_orders as u64);
     info!("🚀️ test complete");
 }

--- a/tari_payment_server/src/config.rs
+++ b/tari_payment_server/src/config.rs
@@ -52,6 +52,8 @@ pub struct ServerConfig {
     pub unpaid_order_timeout: Duration,
     /// Shopify storefront configuration
     pub shopify_config: ShopifyConfig,
+    /// The maximum number of database connections to allow in the database pool
+    pub max_connections: u32,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -88,6 +90,7 @@ impl Default for ServerConfig {
             unclaimed_order_timeout: DEFAULT_UNCLAIMED_ORDER_TIMEOUT,
             unpaid_order_timeout: DEFAULT_UNPAID_ORDER_TIMEOUT,
             shopify_config: ShopifyConfig::default(),
+            max_connections: 25,
         }
     }
 }
@@ -183,6 +186,17 @@ impl ServerConfig {
         let disable_memo_signature_check =
             env::var("TPG_DISABLE_MEMO_SIGNATURE_CHECK").map(|s| &s == "1" || &s == "true").unwrap_or(false);
         let (unclaimed_order_timeout, unpaid_order_timeout) = configure_order_timeouts();
+        let max_connections = env::var("TPG_MAX_CONNECTIONS")
+            .map(|s| {
+                s.parse::<u32>().unwrap_or_else(|e| {
+                    warn!(
+                        "🪛️ {s} is not a valid value for TPG_MAX_CONNECTIONS. {e} Using the default value of 25 \
+                         instead."
+                    );
+                    25
+                })
+            })
+            .unwrap_or(25);
         Self {
             host,
             port,
@@ -196,6 +210,7 @@ impl ServerConfig {
             disable_memo_signature_check,
             unclaimed_order_timeout,
             unpaid_order_timeout,
+            max_connections,
         }
     }
 }

--- a/tari_payment_server/src/integrations/shopify.rs
+++ b/tari_payment_server/src/integrations/shopify.rs
@@ -1,4 +1,3 @@
-use actix_web::web::trace;
 use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
 use log::*;

--- a/tari_payment_server/src/server.rs
+++ b/tari_payment_server/src/server.rs
@@ -88,7 +88,7 @@ const LOG_FORMAT: &str = concat!(
 );
 
 pub async fn run_server(config: ServerConfig) -> Result<(), ServerError> {
-    let db = SqliteDatabase::new_with_url(&config.database_url, 25)
+    let db = SqliteDatabase::new_with_url(&config.database_url, config.max_connections)
         .await
         .map_err(|e| ServerError::InitializeError(e.to_string()))?;
     // Shopify is the only supported integration at the moment. In future, this would be conditional code based on a


### PR DESCRIPTION
Adds `TPG_MAX_CONNECTIONS` as a configuration variable which allows the
administrator to set the maximum number of DB connections in the pool.
This value was previously hard-coded as 25.

The default remains at 25.