### PR TITLE
feat: capture shopify payments

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,6 +14,10 @@ TPG_SHOPIFY_STOREFRONT_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TPG_STRICT_MODE=1
 TPG_SHOPIFY_ORDER_ID_FIELD=id
 TPG_SHOPIFY_PRICE_FIELD=total
+# If 1, the shopify store is set up to collect fiat payments for shipping and taxes.
+# It's assumed that in this case, the discounts feature is used to split the order. If 1 then `TPG_SHOPIFY_PRICE_FIELD`
+# should also be set to "line"
+TPG_SHOPIFY_CAPTURE_PAYMENTS=0
 TPG_MAX_CONNECTIONS=25
 
 RUST_LOG="error,shopify_payment_gateway=trace"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4369,6 +4369,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "shopify_tools",
  "sqlx",
  "tari_common",
  "tari_common_types",

--- a/SHOPIFY_INTEGRATION.md
+++ b/SHOPIFY_INTEGRATION.md
@@ -138,6 +138,11 @@ TPS assumes that the following environment variables are set when making use of 
   Set to `1` to enable HMAC checks, and `0` to disable them. You **almost certainly want to enable this in production.**
 - `TPG_SHOPIFY_ORDER_ID_FIELD`. Specify which field should be used as the order id. Must be one of `name` or `id`. 
    Default is `id`.
+- `TPG_SHOPIFY_CAPTURE_PAYMENTS`. Indicates that TPS should capture authorizations rather than via the shopify app. 
+   You can choose to authorise payments made via Shopify Payments with Tari Payment Server. Any authorizations made 
+   on the site that are not automatically captured will be captured once the Tari payment has been received in full.
+   As usual, you should set Shopify to capture payments manually.  You can then use a discount to reduce the 
+   USD-based price of orders, and the balance will be configured to be paid by Tari.
   
 ## Configure webhooks to interact with your server.
 

--- a/e2e/tests/cucumber/setup.rs
+++ b/e2e/tests/cucumber/setup.rs
@@ -299,6 +299,7 @@ async fn server_configuration(world: &mut TPGWorld, step: &Step) {
             },
             "strict_mode" => world.config.strict_mode = value == "true",
             "price_field" => world.config.shopify_config.price_field = value.parse().expect("Invalid price field"),
+            "capture_payments" => world.config.shopify_config.capture_payments = value == "true",
             _ => warn!("Unknown configuration key: {key}"),
         }
     });

--- a/e2e/tests/cucumber/setup.rs
+++ b/e2e/tests/cucumber/setup.rs
@@ -32,6 +32,7 @@ fn seed_orders() -> [NewOrder; 5] {
             total_price: MicroTari::from_tari(100),
             original_price: None,
             created_at: Utc.with_ymd_and_hms(2024, 3, 10, 15, 0, 0).unwrap(),
+            amount_outstanding: Some("0.00".into()),
         },
         NewOrder {
             order_id: OrderId::new("2"),
@@ -43,6 +44,7 @@ fn seed_orders() -> [NewOrder; 5] {
             total_price: MicroTari::from_tari(200),
             original_price: None,
             created_at: Utc.with_ymd_and_hms(2024, 3, 10, 15, 30, 0).unwrap(),
+            amount_outstanding: Some("5.00".into()),
         },
         NewOrder {
             order_id: OrderId::new("3"),
@@ -54,6 +56,7 @@ fn seed_orders() -> [NewOrder; 5] {
             total_price: MicroTari::from_tari(65),
             original_price: None,
             created_at: Utc.with_ymd_and_hms(2024, 3, 11, 16, 0, 0).unwrap(),
+            amount_outstanding: None,
         },
         NewOrder {
             order_id: OrderId::new("4"),
@@ -65,6 +68,7 @@ fn seed_orders() -> [NewOrder; 5] {
             total_price: MicroTari::from_tari(350),
             original_price: None,
             created_at: Utc.with_ymd_and_hms(2024, 3, 11, 17, 0, 0).unwrap(),
+            amount_outstanding: Some("0.00".into()),
         },
         NewOrder {
             order_id: OrderId::new("5"),
@@ -76,6 +80,7 @@ fn seed_orders() -> [NewOrder; 5] {
             total_price: MicroTari::from_tari(25),
             original_price: None,
             created_at: Utc.with_ymd_and_hms(2024, 3, 12, 18, 0, 0).unwrap(),
+            amount_outstanding: None,
         },
     ]
 }

--- a/shopify_tools/src/config.rs
+++ b/shopify_tools/src/config.rs
@@ -1,5 +1,5 @@
 use log::*;
-use tpg_common::Secret;
+use tpg_common::{helpers::parse_boolean_flag, Secret};
 
 #[derive(Debug, Clone, Default)]
 pub struct ShopifyConfig {
@@ -8,6 +8,7 @@ pub struct ShopifyConfig {
     pub storefront_access_token: Secret<String>,
     pub api_version: String,
     pub shared_secret: Secret<String>,
+    pub capture_payments: bool,
 }
 
 impl ShopifyConfig {
@@ -36,6 +37,14 @@ impl ShopifyConfig {
             );
             "00000000000000".to_string()
         }));
-        Self { shop, admin_access_token, api_version, shared_secret, storefront_access_token }
+        let external_shipping_payments = parse_boolean_flag(std::env::var("TPG_SHOPIFY_CAPTURE_PAYMENTS").ok(), false);
+        Self {
+            shop,
+            admin_access_token,
+            api_version,
+            shared_secret,
+            storefront_access_token,
+            capture_payments: external_shipping_payments,
+        }
     }
 }

--- a/shopify_tools/src/lib.rs
+++ b/shopify_tools/src/lib.rs
@@ -15,4 +15,10 @@ pub use data_objects::{ExchangeRate, ExchangeRates};
 pub use error::ShopifyApiError;
 pub use shopify_order::{Customer, EmailMarketingConsent, OrderBuilder, ShopifyOrder};
 pub use shopify_product::{ProductImage, ShopifyProduct, Variant};
-pub use shopify_transaction::{CurrencyExchangeAdjustment, OutstandingValue, ShopifyTransaction};
+pub use shopify_transaction::{
+    CaptureTransaction,
+    CurrencyExchangeAdjustment,
+    OutstandingValue,
+    ShopifyPaymentCapture,
+    ShopifyTransaction,
+};

--- a/shopify_tools/src/shopify_order.rs
+++ b/shopify_tools/src/shopify_order.rs
@@ -30,6 +30,7 @@ pub struct ShopifyOrder {
     pub total_price: String,
     pub total_tax: String,
     pub subtotal_price: String,
+    pub total_outstanding: String,
     pub customer: Customer,
 }
 
@@ -93,6 +94,7 @@ pub struct OrderBuilder {
     total_discounts: Option<String>,
     total_line_items_price: Option<String>,
     total_price: Option<String>,
+    total_outstanding: Option<String>,
     total_tax: Option<String>,
     subtotal_price: Option<String>,
     customer: Option<Customer>,
@@ -183,6 +185,11 @@ impl OrderBuilder {
         self
     }
 
+    pub fn total_outstanding(&mut self, outstanding: String) -> &mut Self {
+        self.total_outstanding = Some(outstanding);
+        self
+    }
+
     pub fn customer(&mut self, customer: Customer) -> &mut Self {
         self.customer = Some(customer);
         self
@@ -216,6 +223,7 @@ impl OrderBuilder {
             total_line_items_price: self.total_line_items_price.unwrap_or_default(),
             total_price: self.total_price.unwrap_or_else(|| format!("{}", rng.gen_range(1_000..250_000) * 1000)),
             total_tax: self.total_tax.unwrap_or_default(),
+            total_outstanding: self.total_outstanding.unwrap_or_default(),
             subtotal_price: self.subtotal_price.unwrap_or_default(),
             customer: self.customer.unwrap_or_default(),
             checkout_token: None,

--- a/shopify_tools/src/shopify_transaction.rs
+++ b/shopify_tools/src/shopify_transaction.rs
@@ -14,7 +14,7 @@ pub struct ShopifyTransaction {
     pub gateway: Option<String>,
     pub kind: String,
     pub message: String,
-    pub parent_id: i64,
+    pub parent_id: Option<i64>,
     pub processed_at: String,
     pub source_name: String,
     pub status: String,
@@ -43,6 +43,20 @@ pub struct OutstandingValue {
 pub struct TotalUnsettledSet {
     pub presentment_money: OutstandingValue,
     pub shop_money: OutstandingValue,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ShopifyPaymentCapture {
+    pub transaction: CaptureTransaction,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CaptureTransaction {
+    pub parent_id: i64,
+    pub kind: String,
+    pub amount: String,
+    pub currency: String,
+    pub test: bool,
 }
 
 #[cfg(test)]

--- a/shopify_tools/src/test_assets/checkout_create.json
+++ b/shopify_tools/src/test_assets/checkout_create.json
@@ -1,0 +1,372 @@
+{
+  "id": 5796499259604,
+  "admin_graphql_api_id": "gid://shopify/Order/5796499259604",
+  "app_id": 580111,
+  "browser_ip": "94.63.235.150",
+  "buyer_accepts_marketing": false,
+  "cancel_reason": null,
+  "cancelled_at": null,
+  "cart_token": "Z2NwLXVzLWVhc3QxOjAxSkJWREIzSFIySDU1Uko0MEpaWVNTTkcw",
+  "checkout_id": 36828373647572,
+  "checkout_token": "550c51c944eb28b9e2eb73a5d2028634",
+  "client_details": {
+    "accept_language": "en-US",
+    "browser_height": null,
+    "browser_ip": "94.63.235.150",
+    "browser_width": null,
+    "session_hash": null,
+    "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:132.0) Gecko/20100101 Firefox/132.0"
+  },
+  "closed_at": null,
+  "confirmation_number": "87U59TQ4X",
+  "confirmed": true,
+  "contact_email": "cj+bob@tari.com",
+  "created_at": "2024-11-04T11:02:37+00:00",
+  "currency": "USD",
+  "current_subtotal_price": "0.00",
+  "current_subtotal_price_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_additional_fees_set": null,
+  "current_total_discounts": "8.00",
+  "current_total_discounts_set": {
+    "shop_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_duties_set": null,
+  "current_total_price": "6.90",
+  "current_total_price_set": {
+    "shop_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_tax": "0.00",
+  "current_total_tax_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "customer_locale": "en-US",
+  "device_id": null,
+  "discount_codes": [],
+  "email": "cj+bob@tari.com",
+  "estimated_taxes": false,
+  "financial_status": "authorized",
+  "fulfillment_status": null,
+  "landing_site": "/",
+  "landing_site_ref": null,
+  "location_id": null,
+  "merchant_of_record_app_id": null,
+  "name": "#1140",
+  "note": null,
+  "note_attributes": [],
+  "number": 140,
+  "order_number": 1140,
+  "order_status_url": "https://af2f05-9a.myshopify.com/70504906964/orders/b188fb34bd52cc8ddd450ce468d1e6e8/authenticate?key=cb308f1c254215faf4f2982acc092e56",
+  "original_total_additional_fees_set": null,
+  "original_total_duties_set": null,
+  "payment_gateway_names": [
+    "shopify_payments"
+  ],
+  "phone": null,
+  "po_number": null,
+  "presentment_currency": "USD",
+  "processed_at": "2024-11-04T11:02:33+00:00",
+  "reference": "815eb33370868b01fc2d3eead36cfaef",
+  "referring_site": "https://af2f05-9a.myshopify.com/",
+  "source_identifier": "815eb33370868b01fc2d3eead36cfaef",
+  "source_name": "web",
+  "source_url": null,
+  "subtotal_price": "0.00",
+  "subtotal_price_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "tags": "",
+  "tax_exempt": false,
+  "tax_lines": [],
+  "taxes_included": false,
+  "test": true,
+  "token": "b188fb34bd52cc8ddd450ce468d1e6e8",
+  "total_discounts": "8.00",
+  "total_discounts_set": {
+    "shop_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_line_items_price": "8.00",
+  "total_line_items_price_set": {
+    "shop_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_outstanding": "0.00",
+  "total_price": "6.90",
+  "total_price_set": {
+    "shop_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    }
+  },
+  "total_shipping_price_set": {
+    "shop_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    }
+  },
+  "total_tax": "0.00",
+  "total_tax_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_tip_received": "0.00",
+  "total_weight": 0,
+  "updated_at": "2024-11-04T11:02:38+00:00",
+  "user_id": null,
+  "billing_address": {
+    "first_name": null,
+    "address1": "1000 Steps Beach",
+    "phone": null,
+    "city": "Laguna Beach",
+    "zip": "92651",
+    "province": "California",
+    "country": "United States",
+    "last_name": "Bob",
+    "address2": null,
+    "company": null,
+    "latitude": null,
+    "longitude": null,
+    "name": "Bob",
+    "country_code": "US",
+    "province_code": "CA"
+  },
+  "customer": {
+    "id": 7390049927380,
+    "email": "cj+bob@tari.com",
+    "created_at": "2024-07-26T13:46:39+01:00",
+    "updated_at": "2024-11-04T11:02:37+00:00",
+    "first_name": null,
+    "last_name": "Bob",
+    "state": "disabled",
+    "note": null,
+    "verified_email": true,
+    "multipass_identifier": null,
+    "tax_exempt": false,
+    "phone": null,
+    "email_marketing_consent": {
+      "state": "not_subscribed",
+      "opt_in_level": "single_opt_in",
+      "consent_updated_at": null
+    },
+    "sms_marketing_consent": null,
+    "tags": "",
+    "currency": "USD",
+    "tax_exemptions": [],
+    "admin_graphql_api_id": "gid://shopify/Customer/7390049927380",
+    "default_address": {
+      "id": 9100299075796,
+      "customer_id": 7390049927380,
+      "first_name": null,
+      "last_name": "Bob",
+      "company": null,
+      "address1": "1000 Steps Beach",
+      "address2": null,
+      "city": "Laguna Beach",
+      "province": "California",
+      "country": "United States",
+      "zip": "92651",
+      "phone": null,
+      "name": "Bob",
+      "province_code": "CA",
+      "country_code": "US",
+      "country_name": "United States",
+      "default": true
+    }
+  },
+  "discount_applications": [
+    {
+      "target_type": "line_item",
+      "type": "automatic",
+      "value": "100.0",
+      "value_type": "percentage",
+      "allocation_method": "across",
+      "target_selection": "all",
+      "title": "Pay with Tari"
+    }
+  ],
+  "fulfillments": [],
+  "line_items": [
+    {
+      "id": 14231721443540,
+      "admin_graphql_api_id": "gid://shopify/LineItem/14231721443540",
+      "attributed_staffs": [],
+      "current_quantity": 1,
+      "fulfillable_quantity": 1,
+      "fulfillment_service": "manual",
+      "fulfillment_status": null,
+      "gift_card": false,
+      "grams": 0,
+      "name": "TA/RI Hat - S/M",
+      "price": "8.00",
+      "price_set": {
+        "shop_money": {
+          "amount": "8.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "8.00",
+          "currency_code": "USD"
+        }
+      },
+      "product_exists": true,
+      "product_id": 8494452965588,
+      "properties": [],
+      "quantity": 1,
+      "requires_shipping": true,
+      "sku": "TTL101_HAT_ROCK_SM",
+      "taxable": true,
+      "title": "TA/RI Hat",
+      "total_discount": "0.00",
+      "total_discount_set": {
+        "shop_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        }
+      },
+      "variant_id": 45280626311380,
+      "variant_inventory_management": "shopify",
+      "variant_title": "S/M",
+      "vendor": "The TTL Store",
+      "tax_lines": [],
+      "duties": [],
+      "discount_allocations": [
+        {
+          "amount": "8.00",
+          "amount_set": {
+            "shop_money": {
+              "amount": "8.00",
+              "currency_code": "USD"
+            },
+            "presentment_money": {
+              "amount": "8.00",
+              "currency_code": "USD"
+            }
+          },
+          "discount_application_index": 0
+        }
+      ]
+    }
+  ],
+  "payment_terms": null,
+  "refunds": [],
+  "shipping_address": {
+    "first_name": null,
+    "address1": "1000 Steps Beach",
+    "phone": null,
+    "city": "Laguna Beach",
+    "zip": "92651",
+    "province": "California",
+    "country": "United States",
+    "last_name": "Bob",
+    "address2": null,
+    "company": null,
+    "latitude": 33.4979923,
+    "longitude": -117.7406857,
+    "name": "Bob",
+    "country_code": "US",
+    "province_code": "CA"
+  },
+  "shipping_lines": [
+    {
+      "id": 4669553344724,
+      "carrier_identifier": null,
+      "code": "Standard",
+      "discounted_price": "6.90",
+      "discounted_price_set": {
+        "shop_money": {
+          "amount": "6.90",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "6.90",
+          "currency_code": "USD"
+        }
+      },
+      "is_removed": false,
+      "phone": null,
+      "price": "6.90",
+      "price_set": {
+        "shop_money": {
+          "amount": "6.90",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "6.90",
+          "currency_code": "USD"
+        }
+      },
+      "requested_fulfillment_service_id": null,
+      "source": "shopify",
+      "title": "Standard",
+      "tax_lines": [],
+      "discount_allocations": []
+    }
+  ]
+}

--- a/shopify_tools/src/test_assets/order_transactions_create.json
+++ b/shopify_tools/src/test_assets/order_transactions_create.json
@@ -1,0 +1,176 @@
+{
+  "id": 6887976009940,
+  "order_id": 5796499259604,
+  "kind": "authorization",
+  "gateway": "shopify_payments",
+  "status": "success",
+  "message": "Transaction approved",
+  "created_at": "2024-11-04T11:02:34+00:00",
+  "test": true,
+  "authorization": "pi_3QHO3KR6Nla0yhHk1GTDaDYU",
+  "location_id": null,
+  "user_id": null,
+  "parent_id": null,
+  "processed_at": "2024-11-04T11:02:34+00:00",
+  "device_id": null,
+  "error_code": null,
+  "source_name": "checkout_one",
+  "payment_details": {
+    "credit_card_bin": "424242",
+    "avs_result_code": "Y",
+    "cvv_result_code": "M",
+    "credit_card_number": "•••• •••• •••• 4242",
+    "credit_card_company": "Visa",
+    "buyer_action_info": null,
+    "credit_card_name": "Bob",
+    "credit_card_wallet": null,
+    "credit_card_expiration_month": 2,
+    "credit_card_expiration_year": 2032,
+    "payment_method_name": "visa"
+  },
+  "receipt": {
+    "id": "pi_3QHO3KR6Nla0yhHk1GTDaDYU",
+    "object": "payment_intent",
+    "amount": 690,
+    "amount_capturable": 690,
+    "amount_received": 0,
+    "canceled_at": null,
+    "cancellation_reason": null,
+    "capture_method": "manual",
+    "charges": {
+      "object": "list",
+      "data": [
+        {
+          "id": "ch_3QHO3KR6Nla0yhHk1JzU7OaI",
+          "object": "charge",
+          "amount": 690,
+          "application_fee": null,
+          "balance_transaction": null,
+          "captured": false,
+          "created": 1730718154,
+          "currency": "usd",
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "livemode": false,
+          "metadata": {
+            "email": "cj+bob@tari.com",
+            "manual_entry": "false",
+            "order_id": "r7LxCEdHT3BNmVRm4gTb10HrR",
+            "order_transaction_id": "6887976009940",
+            "payments_charge_id": "2649824592084",
+            "shop_id": "70504906964",
+            "shop_name": "Tari Merch Testing Store",
+            "shopify_payments_next": "true"
+          },
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 8,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3QHO3KR6Nla0yhHk1GTDaDYU",
+          "payment_method": "pm_1QHO3KR6Nla0yhHk0A7A72jQ",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 690,
+              "authorization_code": null,
+              "brand": "visa",
+              "capture_before": 1733137354,
+              "checks": {
+                "address_line1_check": "pass",
+                "address_postal_code_check": "pass",
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "description": "Visa Classic",
+              "ds_transaction_id": null,
+              "exp_month": 2,
+              "exp_year": 2032,
+              "extended_authorization": {
+                "status": "enabled"
+              },
+              "fingerprint": "2M23dVRniScqT7K2",
+              "funding": "credit",
+              "iin": "424242",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "issuer": "Stripe Payments UK Limited",
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "501217186106113",
+              "overcapture": {
+                "maximum_amount_capturable": 793,
+                "status": "available"
+              },
+              "overcapture_supported": true,
+              "payment_account_reference": "xR4eIL3CZCjH9hMkhqeysHPkE5Zxs",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "refunded": false,
+          "source": null,
+          "status": "succeeded",
+          "mit_params": {
+            "network_transaction_id": "501217186106113"
+          }
+        }
+      ],
+      "has_more": false,
+      "total_count": 1,
+      "url": "/v1/charges?payment_intent=pi_3QHO3KR6Nla0yhHk1GTDaDYU"
+    },
+    "confirmation_method": "manual",
+    "created": 1730718154,
+    "currency": "usd",
+    "last_payment_error": null,
+    "livemode": false,
+    "metadata": {
+      "email": "cj+bob@tari.com",
+      "manual_entry": "false",
+      "order_id": "r7LxCEdHT3BNmVRm4gTb10HrR",
+      "order_transaction_id": "6887976009940",
+      "payments_charge_id": "2649824592084",
+      "shop_id": "70504906964",
+      "shop_name": "Tari Merch Testing Store",
+      "shopify_payments_next": "true"
+    },
+    "next_action": null,
+    "payment_method": "pm_1QHO3KR6Nla0yhHk0A7A72jQ",
+    "payment_method_types": [
+      "card"
+    ],
+    "source": null,
+    "status": "requires_capture"
+  },
+  "amount": "6.90",
+  "currency": "USD",
+  "payment_id": "r7LxCEdHT3BNmVRm4gTb10HrR",
+  "total_unsettled_set": {
+    "presentment_money": {
+      "amount": "6.9",
+      "currency": "USD"
+    },
+    "shop_money": {
+      "amount": "6.9",
+      "currency": "USD"
+    }
+  },
+  "manual_payment_gateway": false,
+  "admin_graphql_api_id": "gid://shopify/OrderTransaction/6887976009940"
+}

--- a/shopify_tools/src/test_assets/orders_updated.json
+++ b/shopify_tools/src/test_assets/orders_updated.json
@@ -1,0 +1,372 @@
+{
+  "id": 5796499259604,
+  "admin_graphql_api_id": "gid://shopify/Order/5796499259604",
+  "app_id": 580111,
+  "browser_ip": "94.63.235.150",
+  "buyer_accepts_marketing": false,
+  "cancel_reason": null,
+  "cancelled_at": null,
+  "cart_token": "Z2NwLXVzLWVhc3QxOjAxSkJWREIzSFIySDU1Uko0MEpaWVNTTkcw",
+  "checkout_id": 36828373647572,
+  "checkout_token": "550c51c944eb28b9e2eb73a5d2028634",
+  "client_details": {
+    "accept_language": "en-US",
+    "browser_height": null,
+    "browser_ip": "94.63.235.150",
+    "browser_width": null,
+    "session_hash": null,
+    "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:132.0) Gecko/20100101 Firefox/132.0"
+  },
+  "closed_at": null,
+  "confirmation_number": "87U59TQ4X",
+  "confirmed": true,
+  "contact_email": "cj+bob@tari.com",
+  "created_at": "2024-11-04T11:02:37+00:00",
+  "currency": "USD",
+  "current_subtotal_price": "0.00",
+  "current_subtotal_price_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_additional_fees_set": null,
+  "current_total_discounts": "8.00",
+  "current_total_discounts_set": {
+    "shop_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_duties_set": null,
+  "current_total_price": "6.90",
+  "current_total_price_set": {
+    "shop_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    }
+  },
+  "current_total_tax": "0.00",
+  "current_total_tax_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "customer_locale": "en-US",
+  "device_id": null,
+  "discount_codes": [],
+  "email": "cj+bob@tari.com",
+  "estimated_taxes": false,
+  "financial_status": "authorized",
+  "fulfillment_status": null,
+  "landing_site": "/",
+  "landing_site_ref": null,
+  "location_id": null,
+  "merchant_of_record_app_id": null,
+  "name": "#1140",
+  "note": null,
+  "note_attributes": [],
+  "number": 140,
+  "order_number": 1140,
+  "order_status_url": "https://af2f05-9a.myshopify.com/70504906964/orders/b188fb34bd52cc8ddd450ce468d1e6e8/authenticate?key=cb308f1c254215faf4f2982acc092e56",
+  "original_total_additional_fees_set": null,
+  "original_total_duties_set": null,
+  "payment_gateway_names": [
+    "shopify_payments"
+  ],
+  "phone": null,
+  "po_number": null,
+  "presentment_currency": "USD",
+  "processed_at": "2024-11-04T11:02:33+00:00",
+  "reference": "815eb33370868b01fc2d3eead36cfaef",
+  "referring_site": "https://af2f05-9a.myshopify.com/",
+  "source_identifier": "815eb33370868b01fc2d3eead36cfaef",
+  "source_name": "web",
+  "source_url": null,
+  "subtotal_price": "0.00",
+  "subtotal_price_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "tags": "",
+  "tax_exempt": false,
+  "tax_lines": [],
+  "taxes_included": false,
+  "test": true,
+  "token": "b188fb34bd52cc8ddd450ce468d1e6e8",
+  "total_discounts": "8.00",
+  "total_discounts_set": {
+    "shop_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_line_items_price": "8.00",
+  "total_line_items_price_set": {
+    "shop_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "8.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_outstanding": "0.00",
+  "total_price": "6.90",
+  "total_price_set": {
+    "shop_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    }
+  },
+  "total_shipping_price_set": {
+    "shop_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "6.90",
+      "currency_code": "USD"
+    }
+  },
+  "total_tax": "0.00",
+  "total_tax_set": {
+    "shop_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    },
+    "presentment_money": {
+      "amount": "0.00",
+      "currency_code": "USD"
+    }
+  },
+  "total_tip_received": "0.00",
+  "total_weight": 0,
+  "updated_at": "2024-11-04T11:02:38+00:00",
+  "user_id": null,
+  "billing_address": {
+    "first_name": null,
+    "address1": "1000 Steps Beach",
+    "phone": null,
+    "city": "Laguna Beach",
+    "zip": "92651",
+    "province": "California",
+    "country": "United States",
+    "last_name": "Bob",
+    "address2": null,
+    "company": null,
+    "latitude": null,
+    "longitude": null,
+    "name": "Bob",
+    "country_code": "US",
+    "province_code": "CA"
+  },
+  "customer": {
+    "id": 7390049927380,
+    "email": "cj+bob@tari.com",
+    "created_at": "2024-07-26T13:46:39+01:00",
+    "updated_at": "2024-11-04T11:02:37+00:00",
+    "first_name": null,
+    "last_name": "Bob",
+    "state": "disabled",
+    "note": null,
+    "verified_email": true,
+    "multipass_identifier": null,
+    "tax_exempt": false,
+    "phone": null,
+    "email_marketing_consent": {
+      "state": "not_subscribed",
+      "opt_in_level": "single_opt_in",
+      "consent_updated_at": null
+    },
+    "sms_marketing_consent": null,
+    "tags": "",
+    "currency": "USD",
+    "tax_exemptions": [],
+    "admin_graphql_api_id": "gid://shopify/Customer/7390049927380",
+    "default_address": {
+      "id": 9100299075796,
+      "customer_id": 7390049927380,
+      "first_name": null,
+      "last_name": "Bob",
+      "company": null,
+      "address1": "1000 Steps Beach",
+      "address2": null,
+      "city": "Laguna Beach",
+      "province": "California",
+      "country": "United States",
+      "zip": "92651",
+      "phone": null,
+      "name": "Bob",
+      "province_code": "CA",
+      "country_code": "US",
+      "country_name": "United States",
+      "default": true
+    }
+  },
+  "discount_applications": [
+    {
+      "target_type": "line_item",
+      "type": "automatic",
+      "value": "100.0",
+      "value_type": "percentage",
+      "allocation_method": "across",
+      "target_selection": "all",
+      "title": "Pay with Tari"
+    }
+  ],
+  "fulfillments": [],
+  "line_items": [
+    {
+      "id": 14231721443540,
+      "admin_graphql_api_id": "gid://shopify/LineItem/14231721443540",
+      "attributed_staffs": [],
+      "current_quantity": 1,
+      "fulfillable_quantity": 1,
+      "fulfillment_service": "manual",
+      "fulfillment_status": null,
+      "gift_card": false,
+      "grams": 0,
+      "name": "TA/RI Hat - S/M",
+      "price": "8.00",
+      "price_set": {
+        "shop_money": {
+          "amount": "8.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "8.00",
+          "currency_code": "USD"
+        }
+      },
+      "product_exists": true,
+      "product_id": 8494452965588,
+      "properties": [],
+      "quantity": 1,
+      "requires_shipping": true,
+      "sku": "TTL101_HAT_ROCK_SM",
+      "taxable": true,
+      "title": "TA/RI Hat",
+      "total_discount": "0.00",
+      "total_discount_set": {
+        "shop_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "0.00",
+          "currency_code": "USD"
+        }
+      },
+      "variant_id": 45280626311380,
+      "variant_inventory_management": "shopify",
+      "variant_title": "S/M",
+      "vendor": "The TTL Store",
+      "tax_lines": [],
+      "duties": [],
+      "discount_allocations": [
+        {
+          "amount": "8.00",
+          "amount_set": {
+            "shop_money": {
+              "amount": "8.00",
+              "currency_code": "USD"
+            },
+            "presentment_money": {
+              "amount": "8.00",
+              "currency_code": "USD"
+            }
+          },
+          "discount_application_index": 0
+        }
+      ]
+    }
+  ],
+  "payment_terms": null,
+  "refunds": [],
+  "shipping_address": {
+    "first_name": null,
+    "address1": "1000 Steps Beach",
+    "phone": null,
+    "city": "Laguna Beach",
+    "zip": "92651",
+    "province": "California",
+    "country": "United States",
+    "last_name": "Bob",
+    "address2": null,
+    "company": null,
+    "latitude": 33.4979923,
+    "longitude": -117.7406857,
+    "name": "Bob",
+    "country_code": "US",
+    "province_code": "CA"
+  },
+  "shipping_lines": [
+    {
+      "id": 4669553344724,
+      "carrier_identifier": null,
+      "code": "Standard",
+      "discounted_price": "6.90",
+      "discounted_price_set": {
+        "shop_money": {
+          "amount": "6.90",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "6.90",
+          "currency_code": "USD"
+        }
+      },
+      "is_removed": false,
+      "phone": null,
+      "price": "6.90",
+      "price_set": {
+        "shop_money": {
+          "amount": "6.90",
+          "currency_code": "USD"
+        },
+        "presentment_money": {
+          "amount": "6.90",
+          "currency_code": "USD"
+        }
+      },
+      "requested_fulfillment_service_id": null,
+      "source": "shopify",
+      "title": "Standard",
+      "tax_lines": [],
+      "discount_allocations": []
+    }
+  ]
+}

--- a/tari_payment_engine/Cargo.toml
+++ b/tari_payment_engine/Cargo.toml
@@ -6,6 +6,7 @@ description = "Database backend for Tari payment gateway"
 
 [dependencies]
 tpg_common = { version = "1.9.0", path = "../tpg_common" }
+shopify_tools = { version = "1.9.0", path = "../shopify_tools" }
 
 blake2 = "0.10.6"
 chrono = { version = "0.4.31", features = ["serde"] }

--- a/tari_payment_engine/src/db_types.rs
+++ b/tari_payment_engine/src/db_types.rs
@@ -250,6 +250,8 @@ pub struct Order {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub status: OrderStatusType,
+    /// The value outstanding on the order according to the storefront
+    pub amount_outstanding: Option<String>,
 }
 
 impl PartialEq for Order {
@@ -284,6 +286,8 @@ pub struct NewOrder {
     pub currency: String,
     /// The time the order was created on Shopify
     pub created_at: DateTime<Utc>,
+    /// The amount outstanding on the order according to the storefront
+    pub amount_outstanding: Option<String>,
 }
 
 impl NewOrder {
@@ -298,6 +302,7 @@ impl NewOrder {
             currency: "XTR".to_string(),
             created_at: Utc::now(),
             address: None,
+            amount_outstanding: None,
         }
     }
 

--- a/tari_payment_engine/src/lib.rs
+++ b/tari_payment_engine/src/lib.rs
@@ -27,6 +27,7 @@ mod postgres;
 pub mod db_types;
 pub mod events;
 pub mod helpers;
+pub mod shopify_types;
 pub mod tpe_api;
 
 pub mod traits;

--- a/tari_payment_engine/src/shopify_types.rs
+++ b/tari_payment_engine/src/shopify_types.rs
@@ -1,0 +1,38 @@
+use chrono::{DateTime, Utc};
+use shopify_tools::{CaptureTransaction, ShopifyPaymentCapture};
+use sqlx::FromRow;
+
+#[derive(Debug, Clone, FromRow)]
+pub struct ShopifyAuthorization {
+    pub id: i64,
+    pub order_id: i64,
+    pub captured: bool,
+    pub amount: String,
+    pub currency: String,
+    pub test: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<ShopifyAuthorization> for ShopifyPaymentCapture {
+    fn from(auth: ShopifyAuthorization) -> Self {
+        let transaction = CaptureTransaction {
+            parent_id: auth.id,
+            kind: "capture".to_string(),
+            amount: auth.amount,
+            currency: auth.currency,
+            test: auth.test,
+        };
+        Self { transaction }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NewShopifyAuthorization {
+    pub id: i64,
+    pub order_id: i64,
+    pub captured: bool,
+    pub amount: String,
+    pub currency: String,
+    pub test: bool,
+}

--- a/tari_payment_engine/src/sqlite/db/accounts.rs
+++ b/tari_payment_engine/src/sqlite/db/accounts.rs
@@ -142,7 +142,8 @@ pub(crate) async fn orders_for_address(
         orders.currency as currency,
         orders.created_at as created_at,
         orders.updated_at as updated_at,
-        orders.status as status
+        orders.status as status,
+        orders.amount_outstanding as amount_outstanding
     FROM orders JOIN address_customer_id_link ON orders.customer_id = address_customer_id_link.customer_id
     WHERE address = $1
     "#,

--- a/tari_payment_engine/src/sqlite/db/mod.rs
+++ b/tari_payment_engine/src/sqlite/db/mod.rs
@@ -14,6 +14,7 @@ pub mod accounts;
 pub mod auth;
 pub mod exchange_rates;
 pub mod orders;
+pub mod shopify;
 pub mod transfers;
 pub mod wallet_auth;
 

--- a/tari_payment_engine/src/sqlite/db/orders.rs
+++ b/tari_payment_engine/src/sqlite/db/orders.rs
@@ -41,8 +41,9 @@ async fn insert_order(order: NewOrder, conn: &mut SqliteConnection) -> Result<Or
                 total_price,
                 original_price,
                 currency,
-                created_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                created_at,
+                amount_outstanding
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             RETURNING *;
         "#,
     )
@@ -54,6 +55,7 @@ async fn insert_order(order: NewOrder, conn: &mut SqliteConnection) -> Result<Or
     .bind(order.original_price)
     .bind(order.currency)
     .bind(order.created_at)
+    .bind(order.amount_outstanding)
     .fetch_one(conn)
     .await?;
     // The DB should trigger an automatic status entry for the order
@@ -248,6 +250,7 @@ pub(crate) async fn fetch_payable_orders_for_address(
             currency,
             orders.created_at as created_at,
             orders.updated_at as updated_at,
+            amount_outstanding,
             status
         FROM orders JOIN address_customer_id_link ON orders.customer_id = address_customer_id_link.customer_id
         WHERE

--- a/tari_payment_engine/src/sqlite/db/shopify.rs
+++ b/tari_payment_engine/src/sqlite/db/shopify.rs
@@ -1,0 +1,69 @@
+use chrono::Utc;
+use log::debug;
+use sqlx::{Error as SqlxError, SqliteConnection};
+
+use crate::{
+    shopify_types::{NewShopifyAuthorization, ShopifyAuthorization},
+    traits::ShopifyAuthorizationError,
+};
+
+pub async fn insert_new_shopify_auth(
+    auth: NewShopifyAuthorization,
+    conn: &mut SqliteConnection,
+) -> Result<ShopifyAuthorization, ShopifyAuthorizationError> {
+    let result: ShopifyAuthorization = sqlx::query_as(
+        r#"INSERT INTO shopify_transactions
+        (id, order_id, amount, currency, test, captured)
+        VALUES (?, ?, ?, ?, ?, ?)
+        RETURNING *;
+        "#,
+    )
+    .bind(auth.id)
+    .bind(auth.order_id)
+    .bind(auth.amount)
+    .bind(auth.currency)
+    .bind(auth.test)
+    .bind(auth.captured)
+    .fetch_one(conn)
+    .await
+    .map_err(|e| match e {
+        SqlxError::RowNotFound => ShopifyAuthorizationError::NotFound(auth.id, auth.order_id),
+        SqlxError::Database(e) if e.is_unique_violation() => {
+            ShopifyAuthorizationError::AlreadyExists(auth.id, auth.order_id)
+        },
+        e => ShopifyAuthorizationError::DatabaseError(e.to_string()),
+    })?;
+    Ok(result)
+}
+
+pub async fn fetch_auth_by_order_id(
+    oid: i64,
+    conn: &mut SqliteConnection,
+) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError> {
+    let result = sqlx::query_as("SELECT * FROM shopify_transactions WHERE order_id = ?;")
+        .bind(oid)
+        .fetch_all(conn)
+        .await
+        .map_err(|e| ShopifyAuthorizationError::DatabaseError(e.to_string()))?;
+    Ok(result)
+}
+
+/// Set all authorizations for the given order id to the given status.
+/// Returns the number of rows affected.
+pub async fn capture_auth(
+    order_id: i64,
+    capture: bool,
+    conn: &mut SqliteConnection,
+) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError> {
+    let result = sqlx::query_as(
+        "UPDATE shopify_transactions SET captured = $1, updated_at = $2 WHERE id = $3 AND captured != $1RETURNING *;",
+    )
+    .bind(capture)
+    .bind(Utc::now())
+    .bind(order_id)
+    .fetch_all(conn)
+    .await
+    .map_err(|e| ShopifyAuthorizationError::DatabaseError(e.to_string()))?;
+    debug!("Set captured = {capture} for order {order_id}");
+    Ok(result)
+}

--- a/tari_payment_engine/src/sqlite/db/shopify.rs
+++ b/tari_payment_engine/src/sqlite/db/shopify.rs
@@ -56,7 +56,7 @@ pub async fn capture_auth(
     conn: &mut SqliteConnection,
 ) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError> {
     let result = sqlx::query_as(
-        "UPDATE shopify_transactions SET captured = $1, updated_at = $2 WHERE id = $3 AND captured != $1RETURNING *;",
+        "UPDATE shopify_transactions SET captured = $1, updated_at = $2 WHERE id = $3 AND captured != $1 RETURNING *;",
     )
     .bind(capture)
     .bind(Utc::now())

--- a/tari_payment_engine/src/sqlite/migrations/0002_create_payments.down.sql
+++ b/tari_payment_engine/src/sqlite/migrations/0002_create_payments.down.sql
@@ -2,6 +2,6 @@ DROP TRIGGER IF EXISTS orders_no_delete
 DROP INDEX payments_status_idx;
 DROP INDEX payments_sender_idx;
 DROP INDEX payments_id_idx;
-DROP INDEX IF payments_orderid_idx;
+DROP INDEX payments_id_orderid;
 
 DROP TABLE payments;

--- a/tari_payment_engine/src/sqlite/migrations/0011_shopify_orders.down.sql
+++ b/tari_payment_engine/src/sqlite/migrations/0011_shopify_orders.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX shopify_tx_captured;
+DROP INDEX shopify_tx_orderid;
+DROP TABLE shopify_transactions;

--- a/tari_payment_engine/src/sqlite/migrations/0011_shopify_orders.up.sql
+++ b/tari_payment_engine/src/sqlite/migrations/0011_shopify_orders.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE shopify_transactions (
+    id INTEGER PRIMARY KEY,
+    order_id INTEGER NOT NULL,
+    amount TEXT NOT NULL,
+    currency TEXT NOT NULL,
+    test BOOLEAN NOT NULL,
+    captured BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX shopify_tx_captured ON shopify_transactions (captured);
+CREATE INDEX shopify_tx_orderid ON shopify_transactions (order_id);
+
+ALTER TABLE orders ADD COLUMN amount_outstanding TEXT;

--- a/tari_payment_engine/src/tpe_api/exchange_objects.rs
+++ b/tari_payment_engine/src/tpe_api/exchange_objects.rs
@@ -15,10 +15,10 @@ pub struct ExchangeRate {
 impl ExchangeRate {
     /// Create a new ExchangeRate object
     ///
-    /// *NB* The rate is in hundreds of the base unit (i.e. how many microTari in one cent of the base currency)
-    pub fn new(currency: String, rate_per_cent: MicroTari, updated_at: Option<DateTime<Utc>>) -> Self {
+    /// The rate, in Microtari per unit of the base currency
+    pub fn new(currency: String, rate: MicroTari, updated_at: Option<DateTime<Utc>>) -> Self {
         let updated_at = updated_at.unwrap_or_else(Utc::now);
-        Self { base_currency: currency, rate: rate_per_cent, updated_at }
+        Self { base_currency: currency, rate, updated_at }
     }
 
     /// Create a new ExchangeRate object with a rate of 1 base unit per Tari

--- a/tari_payment_engine/src/tpe_api/mod.rs
+++ b/tari_payment_engine/src/tpe_api/mod.rs
@@ -42,5 +42,6 @@ pub mod exchange_rate_api;
 pub mod order_flow_api;
 pub mod order_objects;
 pub mod payment_objects;
+pub mod shopify_tracker_api;
 
 pub mod wallet_api;

--- a/tari_payment_engine/src/tpe_api/shopify_tracker_api.rs
+++ b/tari_payment_engine/src/tpe_api/shopify_tracker_api.rs
@@ -61,7 +61,7 @@ where B: ShopifyAuthorizations
 
     pub async fn set_capture_flag(&self, order_id: i64, capture_flag: bool) -> Result<(), ShopifyAuthorizationError> {
         trace!("📋️☑️ Setting capture flag for order {order_id} to {capture_flag}");
-        let _  = self.db.capture(order_id, capture_flag).await?;
+        let _ = self.db.capture(order_id, capture_flag).await?;
         Ok(())
     }
 }

--- a/tari_payment_engine/src/tpe_api/shopify_tracker_api.rs
+++ b/tari_payment_engine/src/tpe_api/shopify_tracker_api.rs
@@ -58,4 +58,10 @@ where B: ShopifyAuthorizations
         trace!("📋️☑️ Fetching tracking order: {order_id}");
         self.db.fetch_by_order_id(order_id).await
     }
+
+    pub async fn set_capture_flag(&self, order_id: i64, capture_flag: bool) -> Result<(), ShopifyAuthorizationError> {
+        trace!("📋️☑️ Setting capture flag for order {order_id} to {capture_flag}");
+        let _  = self.db.capture(order_id, capture_flag).await?;
+        Ok(())
+    }
 }

--- a/tari_payment_engine/src/tpe_api/shopify_tracker_api.rs
+++ b/tari_payment_engine/src/tpe_api/shopify_tracker_api.rs
@@ -1,0 +1,61 @@
+use std::fmt::Debug;
+
+use log::*;
+
+use crate::{
+    shopify_types::{NewShopifyAuthorization, ShopifyAuthorization},
+    traits::{ShopifyAuthorizationError, ShopifyAuthorizations},
+};
+
+pub struct ShopifyTrackerApi<B> {
+    db: B,
+}
+
+impl<B> Debug for ShopifyTrackerApi<B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ShopifyTrackerApi")
+    }
+}
+
+impl<B> Clone for ShopifyTrackerApi<B>
+where B: ShopifyAuthorizations + Clone
+{
+    fn clone(&self) -> Self {
+        Self { db: self.db.clone() }
+    }
+}
+
+impl<B> ShopifyTrackerApi<B>
+where B: ShopifyAuthorizations
+{
+    pub fn new(db: B) -> Self {
+        Self { db }
+    }
+
+    pub async fn log_authorization(&self, auth: NewShopifyAuthorization) -> Result<(), ShopifyAuthorizationError> {
+        let desc = format!("tx {} (Order {})", auth.id, auth.order_id);
+        info!("📋️☑️ Logging new shopify authorization for {desc}");
+        match self.db.insert_new(auth).await {
+            Ok(_) => {
+                info!("📋️☑️ Shopify order {desc} added to tracking");
+                Ok(())
+            },
+            Err(ShopifyAuthorizationError::AlreadyExists(_, _)) => {
+                info!("📋️☑️ Shopify order {desc} already exists in tracking");
+                Ok(())
+            },
+            Err(e) => {
+                info!("📋️☑️ Shopify order {desc} failed to be added to tracking: {e}");
+                Err(e)
+            },
+        }
+    }
+
+    pub async fn fetch_payment_auth(
+        &self,
+        order_id: i64,
+    ) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError> {
+        trace!("📋️☑️ Fetching tracking order: {order_id}");
+        self.db.fetch_by_order_id(order_id).await
+    }
+}

--- a/tari_payment_engine/src/traits/mod.rs
+++ b/tari_payment_engine/src/traits/mod.rs
@@ -25,6 +25,7 @@ mod auth_management;
 
 mod exchange_rates;
 mod payment_gateway_database;
+mod shopify;
 
 mod wallet_management;
 
@@ -35,4 +36,5 @@ pub use auth_management::{AuthApiError, AuthManagement};
 pub use data_objects::{ExpiryResult, MultiAccountPayment, NewWalletInfo, OrderMovedResult, WalletInfo};
 pub use exchange_rates::{ExchangeRateError, ExchangeRates};
 pub use payment_gateway_database::{PaymentGatewayDatabase, PaymentGatewayError};
+pub use shopify::{ShopifyAuthorizationError, ShopifyAuthorizations};
 pub use wallet_management::{WalletAuth, WalletAuthApiError, WalletManagement, WalletManagementError};

--- a/tari_payment_engine/src/traits/shopify.rs
+++ b/tari_payment_engine/src/traits/shopify.rs
@@ -1,0 +1,36 @@
+use thiserror::Error;
+
+use crate::shopify_types::{NewShopifyAuthorization, ShopifyAuthorization};
+
+#[derive(Debug, Clone, Error)]
+pub enum ShopifyAuthorizationError {
+    #[error("Shopify Authorization {0} for Order {1} not found")]
+    NotFound(i64, i64),
+    #[error("Shopify Authorization {0} for Order {1} already exists")]
+    AlreadyExists(i64, i64),
+    #[error("Database error: {0}")]
+    DatabaseError(String),
+}
+
+impl From<sqlx::Error> for ShopifyAuthorizationError {
+    fn from(e: sqlx::Error) -> Self {
+        ShopifyAuthorizationError::DatabaseError(e.to_string())
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait ShopifyAuthorizations {
+    async fn insert_new(
+        &self,
+        auth: NewShopifyAuthorization,
+    ) -> Result<ShopifyAuthorization, ShopifyAuthorizationError>;
+    /// Fetch all authorizations for the given order id.
+    async fn fetch_by_order_id(&self, order_id: i64) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError>;
+    /// Set all authorizations for the given order id to the given status.
+    /// Returns the updated transaction records.
+    async fn capture(
+        &self,
+        order_id: i64,
+        capture: bool,
+    ) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError>;
+}

--- a/tari_payment_engine/src/traits/shopify.rs
+++ b/tari_payment_engine/src/traits/shopify.rs
@@ -28,9 +28,5 @@ pub trait ShopifyAuthorizations {
     async fn fetch_by_order_id(&self, order_id: i64) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError>;
     /// Set all authorizations for the given order id to the given status.
     /// Returns the updated transaction records.
-    async fn capture(
-        &self,
-        order_id: i64,
-        capture: bool,
-    ) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError>;
+    async fn capture(&self, order_id: i64, capture: bool) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError>;
 }

--- a/tari_payment_engine/src/traits/shopify.rs
+++ b/tari_payment_engine/src/traits/shopify.rs
@@ -28,5 +28,9 @@ pub trait ShopifyAuthorizations {
     async fn fetch_by_order_id(&self, order_id: i64) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError>;
     /// Set all authorizations for the given order id to the given status.
     /// Returns the updated transaction records.
-    async fn capture(&self, order_id: i64, capture: bool) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError>;
+    async fn capture(
+        &self,
+        order_id: i64,
+        capture: bool,
+    ) -> Result<Vec<ShopifyAuthorization>, ShopifyAuthorizationError>;
 }

--- a/tari_payment_engine/tests/burst_orders.rs
+++ b/tari_payment_engine/tests/burst_orders.rs
@@ -15,7 +15,7 @@ use tari_payment_engine::{
     OrderFlowApi,
     SqliteDatabase,
 };
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Builder;
 use tpg_common::MicroTari;
 
 const NUM_BATCHES: usize = 20;

--- a/tari_payment_server/src/endpoint_tests/orders.rs
+++ b/tari_payment_server/src/endpoint_tests/orders.rs
@@ -102,6 +102,7 @@ fn orders_response(_: &TariAddress) -> Result<Vec<Order>, AccountApiError> {
             created_at: Utc.with_ymd_and_hms(2024, 2, 29, 13, 30, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2024, 2, 29, 13, 30, 0).unwrap(),
             status: OrderStatusType::Paid,
+            amount_outstanding: None,
         },
         Order {
             id: 1,
@@ -115,8 +116,9 @@ fn orders_response(_: &TariAddress) -> Result<Vec<Order>, AccountApiError> {
             created_at: Utc.with_ymd_and_hms(2024, 3, 15, 18, 30, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2024, 3, 16, 11, 20, 0).unwrap(),
             status: OrderStatusType::Cancelled,
+            amount_outstanding: None,
         },
     ])
 }
 
-const ORDERS_JSON: &str = r##"{"address":"14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2","total_orders":250,"orders":[{"id":0,"order_id":"0000001","alt_id":"#1001","customer_id":"1","memo":null,"total_price":100,"original_price":null,"currency":"XTR","created_at":"2024-02-29T13:30:00Z","updated_at":"2024-02-29T13:30:00Z","status":"Paid"},{"id":1,"order_id":"0000002","alt_id":"#1002","customer_id":"1","memo":null,"total_price":150,"original_price":null,"currency":"XTR","created_at":"2024-03-15T18:30:00Z","updated_at":"2024-03-16T11:20:00Z","status":"Cancelled"}]}"##;
+const ORDERS_JSON: &str = r##"{"address":"14AYt2hhhn4VydAXNJ6i7ZfRNZGoGSp713dHjMYCoK5hYw2","total_orders":250,"orders":[{"id":0,"order_id":"0000001","alt_id":"#1001","customer_id":"1","memo":null,"total_price":100,"original_price":null,"currency":"XTR","created_at":"2024-02-29T13:30:00Z","updated_at":"2024-02-29T13:30:00Z","status":"Paid","amount_outstanding":null},{"id":1,"order_id":"0000002","alt_id":"#1002","customer_id":"1","memo":null,"total_price":150,"original_price":null,"currency":"XTR","created_at":"2024-03-15T18:30:00Z","updated_at":"2024-03-16T11:20:00Z","status":"Cancelled","amount_outstanding":null}]}"##;

--- a/tari_payment_server/src/integrations/shopify.rs
+++ b/tari_payment_server/src/integrations/shopify.rs
@@ -194,9 +194,10 @@ fn on_order_paid_handler(
                     );
                     vec![]
                 });
-                // If at least one authorisation is successful, we will update the database for all authorisations related
-                // to the order. There is manual intervention needed anyway, so prefer to handle all of this on the shopify
-                // side. Simple enough to change if this is not the desired behaviour.
+                // If at least one authorisation is successful, we will update the database for all authorisations
+                // related to the order. There is manual intervention needed anyway, so prefer to handle
+                // all of this on the shopify side. Simple enough to change if this is not the desired
+                // behaviour.
                 let mut update_db = false;
                 for auth in auths {
                     if !auth.captured {

--- a/tari_payment_server/src/integrations/shopify.rs
+++ b/tari_payment_server/src/integrations/shopify.rs
@@ -7,13 +7,21 @@ use shopify_tools::{
     ShopifyApiError,
     ShopifyConfig as ShopifyApiConfig,
     ShopifyOrder,
+    ShopifyPaymentCapture,
+    ShopifyTransaction,
 };
 use tari_payment_engine::{
     db_types::{NewOrder, Order, OrderId},
     events::{EventHandlers, EventHooks, OrderAnnulledEvent},
     helpers::MemoSignatureError,
-    tpe_api::{exchange_objects::ExchangeRate, exchange_rate_api::ExchangeRateApi},
+    shopify_types::NewShopifyAuthorization,
+    tpe_api::{
+        exchange_objects::ExchangeRate,
+        exchange_rate_api::ExchangeRateApi,
+        shopify_tracker_api::ShopifyTrackerApi,
+    },
     traits::ExchangeRates,
+    SqliteDatabase,
 };
 use thiserror::Error;
 use tpg_common::TARI_CURRENCY_CODE;
@@ -76,6 +84,7 @@ pub async fn new_order_from_shopify_order<B: ExchangeRates>(
         address: None,
         created_at: timestamp,
         total_price,
+        amount_outstanding: Some(value.total_outstanding),
     };
     if let Err(e) = order.try_extract_address() {
         info!(
@@ -98,10 +107,15 @@ pub const SHOPIFY_EVENT_BUFFER_SIZE: usize = 25;
 /// 2. OrderAnnulledEvent - If an order is cancelled or expires, we send a REST request to the Shopify API to mark the
 ///    order as cancelled. If an order is expired from the Shopify Admin UI, then this REST call will be spurious, but
 ///    no harm will be done.
-pub fn create_shopify_event_handlers(config: ShopifyApiConfig) -> Result<EventHandlers, ShopifyApiError> {
+pub fn create_shopify_event_handlers(
+    config: ShopifyApiConfig,
+    tracker: ShopifyTrackerApi<SqliteDatabase>,
+) -> Result<EventHandlers, ShopifyApiError> {
     let mut hooks = EventHooks::default();
+    let must_capture_payment = config.capture_payments;
     let api = ShopifyApi::new(config)?;
     let api_clone = api.clone();
+    let tracker_clone = tracker.clone();
     // --- On OrderPaid Handler ---
     hooks.on_order_paid(move |ev| {
         let order = ev.order;
@@ -109,18 +123,74 @@ pub fn create_shopify_event_handlers(config: ShopifyApiConfig) -> Result<EventHa
             Some(value) => value,
             None => return no_op(),
         };
-        let Some(original_price) = order.original_price else {
-            error!(
-                "🛍️ The order that has just been marked as paid does not have an original price. Shopify orders \
-                 should
-            have populated this field. TODO: Calculate the original price from the prevailing Tari price. Order \
-                 details: {order:?}"
-            );
-            return no_op();
+        let amount_to_pay = match (must_capture_payment, order.amount_outstanding.clone(), order.original_price.clone())
+        {
+            (false, _, Some(p)) => p,
+            (true, Some(p), _) => p,
+            (false, Some(p), None) => {
+                warn!(
+                    "🛍️ The order that has just been marked as paid does not have an original price. Used the \
+                     outstanding amount instead. {order:?}"
+                );
+                p
+            },
+            (true, None, Some(p)) => {
+                warn!(
+                    "🛍️ The order that has just been marked as paid does not have an outstanding amount, but we are \
+                     being asked to capture external payments. It's possible that this payment request will fail and \
+                     will require a manual override in the storefront. {order:?}"
+                );
+                p
+            },
+            (_, None, None) => {
+                error!(
+                    "🛍️ The order that has just been marked as paid does not have an original or an outstanding \
+                     amount. A manual override in the storefront is required. {order:?}"
+                );
+                return no_op();
+            },
         };
         let api_clone = api_clone.clone();
+        let tracker_clone = tracker_clone.clone();
         Box::pin(async move {
-            match api_clone.mark_order_as_paid(order_id, original_price, order.currency).await {
+            if must_capture_payment {
+                let oid = order_id as i64;
+                let auths = tracker_clone.fetch_payment_auth(oid).await.unwrap_or_else(|e| {
+                    error!(
+                        "🛍️ Error fetching payment authorizations for order {order_id} from the database. {e}. Manual \
+                         intervention is required."
+                    );
+                    vec![]
+                });
+                for auth in auths {
+                    if !auth.captured {
+                        let capture = ShopifyPaymentCapture::from(auth);
+                        match api_clone.capture_payment(oid as i64, capture).await {
+                            Ok(t) => {
+                                info!(
+                                    "🛍️ Order {order_id} payment captured on Shopify. Tx: {} Order: {}. Kind: {}. {}",
+                                    t.id, t.order_id, t.kind, t.message
+                                );
+                            },
+                            Err(e) => {
+                                error!(
+                                    "🛍️ Error capturing payment for order {order_id} on Shopify. Manual intervention \
+                                     is required. {e}"
+                                );
+                            },
+                        }
+                    }
+                }
+            }
+            let due = parse_shopify_price(&amount_to_pay).unwrap_or(1);
+            if due == 0 {
+                info!(
+                    "🛍️ Order {order_id} has been marked as paid on the server, but the amount due is 0. No further \
+                     action required on the storefront."
+                );
+                return;
+            }
+            match api_clone.mark_order_as_paid(order_id, amount_to_pay, order.currency).await {
                 Ok(tx) => info!(
                     "🛍️ Order {order_id} marked as paid on Shopify. New status: {}. Tx id: {}. Errors (if any): {} {}",
                     tx.status,
@@ -171,4 +241,15 @@ fn parse_shopify_order_id(order: &Order) -> Option<u64> {
 
 fn no_op() -> BoxFuture<'static, ()> {
     Box::pin(async {})
+}
+
+pub fn shopify_auth_from_tx(tx: &ShopifyTransaction) -> NewShopifyAuthorization {
+    NewShopifyAuthorization {
+        id: tx.id,
+        order_id: tx.order_id,
+        amount: tx.amount.clone(),
+        currency: tx.currency.clone(),
+        test: tx.test,
+        captured: false,
+    }
 }

--- a/taritools/src/shopify/command_handler.rs
+++ b/taritools/src/shopify/command_handler.rs
@@ -202,8 +202,12 @@ async fn install_webhooks(url: String) {
             return;
         },
     };
-    let params =
-        [("orders/create", make_address("checkout_create")), ("products/update", make_address("product_updated"))];
+    let params = [
+        ("orders/create", make_address("checkout_create")),
+        ("products/update", make_address("product_updated")),
+        ("order_transactions/create", make_address("transaction_create")),
+        ("orders/updated", make_address("no_op")),
+    ];
     for (topic, address) in params {
         match in_existing(topic, &existing_webhooks) {
             Some(webhook) => {

--- a/tpg_common/src/helpers.rs
+++ b/tpg_common/src/helpers.rs
@@ -1,0 +1,12 @@
+/// Parse a boolean flag from a string value, or return the given default value otherwise.
+pub fn parse_boolean_flag(value: Option<String>, default: bool) -> bool {
+    let value = match value {
+        Some(v) => v,
+        None => return default,
+    };
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => true,
+        "0" | "false" | "no" | "off" => false,
+        _ => default,
+    }
+}

--- a/tpg_common/src/lib.rs
+++ b/tpg_common/src/lib.rs
@@ -1,5 +1,6 @@
 mod microtari;
 
+pub mod helpers;
 pub mod op;
 mod secret;
 


### PR DESCRIPTION
You can choose to authorise payments made via Shopify Payments with Tari
Payment Server. Any authorisations made on the site that are not
automatically captured will be captured once the Tari payment has been
received in full.

As usual, you should set Shopify to capture payments manually.
You can then use a discount to reduce the USD-based price of orders, and
the balance will be configured to be paid by Tari.